### PR TITLE
Lookup PDBs for spatial DLLs

### DIFF
--- a/Engine/StackResolver.cs
+++ b/Engine/StackResolver.cs
@@ -575,14 +575,21 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         }
 
         /// This method generates a PowerShell script to automate download of matched PDBs from the public symbol server.
-        public static List<Symbol> GetSymbolDetailsForBinaries(List<string> dllPaths, bool recurse) {
+        public static List<Symbol> GetSymbolDetailsForBinaries(List<string> dllPaths, bool recurse, List<Symbol> existingSymbols = null) {
             if (dllPaths == null || dllPaths.Count == 0) {
                 return new List<Symbol>();
             }
 
             var symbolsFound = new List<Symbol>();
-            var moduleNames = new string[] { "ntdll", "kernel32", "kernelbase", "ntoskrnl", "sqldk", "sqlmin", "sqllang", "sqltses", "sqlaccess", "qds", "hkruntime", "hkengine", "hkcompile", "sqlos", "sqlservr" };
+            var moduleNames = new string[] { "ntdll", "kernel32", "kernelbase", "ntoskrnl", "sqldk", "sqlmin", "sqllang", "sqltses", "sqlaccess", "qds", "hkruntime", "hkengine", "hkcompile", "sqlos", "sqlservr", "SqlServerSpatial*" };
             foreach (var currentModule in moduleNames) {
+                if (null != existingSymbols) {
+                    var syms = existingSymbols.Where(s => string.Equals(s.PDBName, currentModule, StringComparison.InvariantCultureIgnoreCase));
+                    if (syms.Any()) {
+                        symbolsFound.Add(syms.First());
+                        continue;
+                    }
+                }
                 string finalFilePath = null;
 
                 foreach (var currPath in dllPaths) {


### PR DESCRIPTION
* Include SQL spatial native DLLs in list of modules for lookup up PDB
  details.

* Also adds the ability to just retrieve PDB details for modules for which
  PDB info is absent.