### PR TITLE
Improve single-line input handling

### DIFF
--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -49,9 +49,9 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                 return;
             }
 
-            int numLinesOfInput = callStackInput.Text.Length - callStackInput.Text.Replace(Environment.NewLine, string.Empty).Length;
+            bool isSingleLineInput = callStackInput.Text.Length == callStackInput.Text.Replace(Environment.NewLine, string.Empty).Length ? true : false;
 
-            if (1 == numLinesOfInput && !FramesOnSingleLine.Checked) {
+            if (isSingleLineInput && !FramesOnSingleLine.Checked) {
                 if (DialogResult.Yes == MessageBox.Show(this,
                     "Maybe this is intentional, but your input seems to have all the frames on a single line, but the 'Callstack frames are in single line' checkbox is unchecked. " +
                     "This may cause problems resolving symbols. Would you like to enable this?",
@@ -64,7 +64,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                 }
             }
 
-            if (numLinesOfInput > 1 && FramesOnSingleLine.Checked) {
+            if (!isSingleLineInput && FramesOnSingleLine.Checked) {
                 if (DialogResult.Yes == MessageBox.Show(this,
                     "Your input seems to have multiple lines, but the 'Callstack frames are in single line' checkbox is checked. " +
                     "This may cause problems resolving symbols. Would you like to uncheck this setting?",

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -53,6 +53,22 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             }
         }
 
+        /// Test the resolution of a "regular" symbol with virtual address as input.
+        [Fact]
+        [Trait("Category", "Unit")]
+        public void RegularSymbolVirtualAddressMultipleFramesInSingleLine() {
+            using (var csr = new StackResolver()) {
+                var moduleAddressesGood = @"c:\mssql\binn\sqldk.dll 00000001`00400000";
+                Assert.True(csr.ProcessBaseAddresses(moduleAddressesGood));
+                var ret = csr.ResolveCallstacks("prologue   0x000000010042249f     0x0000000100440609   epilogue", @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, true, false, false, true, false, false, null);
+                var expectedSymbol = @"prologue
+sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349
+sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644
+epilogue";
+                Assert.Equal(expectedSymbol, ret.Trim());
+            }
+        }
+
         /// Perf / scale test. We randomly generate 750K XEvents each with 25 frame callstacks, and then resolve them.
         [Fact][Trait("Category", "Perf")]
         public void LargeXEventsInput() {


### PR DESCRIPTION
* Adds a UI pop-up when only single-line input is provided, but the
  single-line intput checkbox is not selected.

* Shift the single-line input line splitting to earlier in the process,
  to ensure that module information lookup, etc, are handled correctly.