### PR TITLE
Trim code and tests

### DIFF
--- a/Engine/StackResolver.cs
+++ b/Engine/StackResolver.cs
@@ -559,15 +559,8 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                 // process any frames which are purely virtual address (in such cases, the caller should have specified base addresses)
                 var callStackLines = PreProcessVAs(ordinalResolvedFrames, rgxVAOnly);
 
-                // locate PDBs for well-known modules, and populate their DIA session helper classes
-                if (DiaUtil.LocateandLoadPDBs(_diautils, tp.symPath, tp.searchPDBsRecursively, wellKnownModuleNames.ToList(), tp.cachePDB, modulesToIgnore)) {
-                    // resolve symbols by using DIA
-                    currstack.Resolvedstack = ResolveSymbols(_diautils, callStackLines, tp.includeSourceInfo, tp.relookupSource, tp.includeOffsets, tp.showInlineFrames, rgxAlreadySymbolizedFrame, rgxModuleName, modulesToIgnore, tp);
-                }
-                else {
-                    currstack.Resolvedstack = string.Empty;
-                    break;
-                }
+                // resolve symbols by using DIA
+                currstack.Resolvedstack = ResolveSymbols(_diautils, callStackLines, tp.includeSourceInfo, tp.relookupSource, tp.includeOffsets, tp.showInlineFrames, rgxAlreadySymbolizedFrame, rgxModuleName, modulesToIgnore, tp);
 
                 var localCounter = Interlocked.Increment(ref this.globalCounter);
                 this.PercentComplete = (int)((double)localCounter / tp.listOfCallStacks.Count * 100.0);

--- a/Engine/StackWithCount.cs
+++ b/Engine/StackWithCount.cs
@@ -8,7 +8,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         public StackWithCount(string callStack, bool framesOnSingleLine, int count) {
             this._framesOnSingleLine = framesOnSingleLine;
             if (framesOnSingleLine) {
-                this._callStack = System.Text.RegularExpressions.Regex.Replace(callStack, @" {2,}", " ");
+                this._callStack = System.Text.RegularExpressions.Regex.Replace(callStack, @"\s{2,}", " ");
             }
             else {
                 this._callStack = callStack;


### PR DESCRIPTION
* Skip proactively loading PDBs for well-known modules. There is no
  impact on perf, as the associated DIA session cache is still present.

* Eliminate a redundant test, and add some "fuzz" to an existing test.

* Remove all repeated whitespace, not just spaces, for single-line
  input.