### PR TITLE
Fix bug in relookup source code path

### DIFF
--- a/Engine/DiaUtil.cs
+++ b/Engine/DiaUtil.cs
@@ -134,7 +134,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             if (enumLineNums.count > 0) {
                 for (uint tmpOrdinal = 0; tmpOrdinal < enumLineNums.count; tmpOrdinal++) {
                     if (tmpOrdinal > 0) {
-                        sbOutput.Append(" -- WARN: multiple matches -- ");
+                        sbOutput.Append(" -- WARNING: multiple matches -- ");
                     }
 
                     sbOutput.Append(string.Format(CultureInfo.CurrentCulture,
@@ -147,7 +147,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             }
             else {
                 if (pdbHasSourceInfo) {
-                    sbOutput.Append("-- WARN: unable to find source info --");
+                    sbOutput.Append("-- WARNING: unable to find source info --");
                 }
             }
             Marshal.FinalReleaseComObject(enumLineNums);
@@ -175,9 +175,9 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                 }
                 Marshal.ReleaseComObject(enumInlinees);
             } catch (COMException) {
-                sbInline.AppendLine(" -- WARN: Unable to process inline frames; maybe symbols are mismatched?");
+                sbInline.AppendLine(" -- WARNING: Unable to process inline frames; maybe symbols are mismatched?");
             } catch (System.ArgumentException) {
-                sbInline.AppendLine(" -- WARN: Unable to process inline frames; maybe symbols are mismatched?");
+                sbInline.AppendLine(" -- WARNING: Unable to process inline frames; maybe symbols are mismatched?");
             }
 
             return sbInline.ToString();

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -133,7 +133,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 
             finalOutput.Text = backgroundTask.Result;
 
-            if (backgroundTask.Result.Contains("-- WARN:")) {
+            if (backgroundTask.Result.Contains("WARNING:")) {
                 MessageBox.Show(this,
                     "One or more potential issues exist in the output. This is sometimes due to mismatched symbols, so please double-check symbol paths and re-run if needed.",
                     "Potential issues with the output",


### PR DESCRIPTION
When re-looking up frames to include source info, we now correctly use
the starting address of the function, and offset into the function, and
then compare to see which line covers that computed address, and then
use the RVA for that line of code to "re-write" the frame in the
module+RVA notation. The earlier implementation used the RVA of the
function to add the offset to, which is incorrect in cases where there
was re-ordering of chunks of machine code done by the compiler in the
process of optimization. Address offset for each function is stable in
these cases as well, and thereby using the mapping offered by the PDB to
get back the actual (sometimes re-located) RVA based on this logic, is
correct behavior.

This change also streamlines the "re-lookup" code path to just re-write
the frame as module+RVA, and thereby allowing other downstream
processing (such as looking up inlinees, etc.) to reuse existing code.