### PR TITLE
Add back the target framework attribute

### DIFF
--- a/Engine/Properties/AssemblyInfo.cs
+++ b/Engine/Properties/AssemblyInfo.cs
@@ -13,3 +13,4 @@
 [assembly: Guid("782bbd60-ee45-43cd-8a4f-0505efe4ff1a")]
 [assembly: AssemblyVersion("2.2.0.0")]
 [assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.7.2", FrameworkDisplayName = ".NET Framework 4.7.2")]

--- a/GUI/Properties/AssemblyInfo.cs
+++ b/GUI/Properties/AssemblyInfo.cs
@@ -14,3 +14,4 @@
 [assembly: AssemblyVersion("2.2.0.0")]
 [assembly: AssemblyFileVersion("2.2.0.0")]
 [assembly: NeutralResourcesLanguage("en")]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.7.2", FrameworkDisplayName = ".NET Framework 4.7.2")]

--- a/Tests/Properties/AssemblyInfo.cs
+++ b/Tests/Properties/AssemblyInfo.cs
@@ -15,3 +15,4 @@ using System.Runtime.InteropServices;
 [assembly: Guid("34ede1d2-801a-407f-9f09-ff9572db8771")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.7.2", FrameworkDisplayName = ".NET Framework 4.7.2")]


### PR DESCRIPTION
Previous commit had set `GenerateTargetFrameworkAttribute` to false,
which seems to have caused an indirect regression in behavior of
HttpRequest to use SSL3. With this attribute,
`ServicePointManager.SecurityProtocol` is restored back to
`SystemDefault`.