### PR TITLE
Update NuGet versions

### DIFF
--- a/Engine/SQLCallStackResolver.Engine.csproj
+++ b/Engine/SQLCallStackResolver.Engine.csproj
@@ -106,12 +106,12 @@
     </ContentWithTargetPath>
   </ItemGroup>
   <ItemGroup>
-    <ContentWithTargetPath Include="..\packages\Microsoft.Debugging.Platform.DbgEng.20220617.1556.0\content\amd64\dbghelp.dll">
+    <ContentWithTargetPath Include="..\packages\Microsoft.Debugging.Platform.DbgEng.20220711.1523.0\content\amd64\dbghelp.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>dbghelp.dll</TargetPath>
       <Link>DebuggerFiles\dbghelp.dll</Link>
     </ContentWithTargetPath>
-    <ContentWithTargetPath Include="..\packages\Microsoft.Debugging.Platform.SymSrv.20220617.1556.0\content\amd64\symsrv.dll">
+    <ContentWithTargetPath Include="..\packages\Microsoft.Debugging.Platform.SymSrv.20220711.1523.0\content\amd64\symsrv.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>symsrv.dll</TargetPath>
       <Link>DebuggerFiles\symsrv.dll</Link>

--- a/Engine/getBuildPreReqs.ps1
+++ b/Engine/getBuildPreReqs.ps1
@@ -2,22 +2,22 @@
 # Licensed under the MIT License - see LICENSE file in this repo.
 
 Write-Host "DIA file versions:"
-$diaFiles = @(dir "../packages/Microsoft.TestPlatform.*/tools/net451/Common7/IDE/Extensions/TestPlatform/x64/msdia140.dll")
+$diaFiles = @(dir "../packages/Microsoft.TestPlatform.17.2.0/tools/net451/Common7/IDE/Extensions/TestPlatform/x64/msdia140.dll")
 foreach ($file in $diaFiles) {
     Write-Host $file.FullName":" $file.VersionInfo.FileVersion
 }
 
-if ((dir "../packages/Microsoft.TestPlatform.*/tools/net451/Common7/IDE/Extensions/TestPlatform/x64/msdia140.*").Length -ne 2) {
+if ((dir "../packages/Microsoft.TestPlatform.17.2.0/tools/net451/Common7/IDE/Extensions/TestPlatform/x64/msdia140.*").Length -ne 2) {
     Write-Error "You must manually obtain msdia140.dll and msdia140.dll.manifest, and copy them to the Engine\DIA sub-folder. Those are redistributable components of Visual Studio 2022 subject to terms as published here: https://docs.microsoft.com/en-us/visualstudio/releases/2022/redistribution." -ErrorAction Stop
 }
 
-$diaManifestPath = "../packages/Microsoft.TestPlatform.*/tools/net451/Common7/IDE/Extensions/TestPlatform/x64/msdia140.dll.manifest"
+$diaManifestPath = "../packages/Microsoft.TestPlatform.17.2.0/tools/net451/Common7/IDE/Extensions/TestPlatform/x64/msdia140.dll.manifest"
 # fix the file path to msdia140.dll within the manifest
 (Get-Content $diaManifestPath).Replace("ComComponents\x64\msdia140.dll", "msdia140.dll") | Set-Content $diaManifestPath
 
 Write-Host "Debugger file versions:"
-$dbgFiles = @(dir "../packages/Microsoft.Debugging.Platform.DbgEng.*/content/amd64/dbghelp.dll")
-$dbgFiles += dir "../packages/Microsoft.Debugging.Platform.SymSrv.*/content/amd64/symsrv.dll"
+$dbgFiles = @(dir "../packages/Microsoft.Debugging.Platform.DbgEng.20220711.1523.0/content/amd64/dbghelp.dll")
+$dbgFiles += dir "../packages/Microsoft.Debugging.Platform.SymSrv.20220711.1523.0/content/amd64/symsrv.dll"
 foreach ($file in $dbgFiles) {
     Write-Host $file.FullName":" $file.VersionInfo.FileVersion
 }

--- a/Engine/packages.config
+++ b/Engine/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--// Copyright (c) Microsoft Corporation. Licensed under the MIT License - see LICENSE file in this repo.-->
 <packages>
-  <package id="Microsoft.Debugging.Platform.DbgEng" version="20220617.1556.0" targetFramework="net472" />
-  <package id="Microsoft.Debugging.Platform.SymSrv" version="20220617.1556.0" targetFramework="net472" />
+  <package id="Microsoft.Debugging.Platform.DbgEng" version="20220711.1523.0" targetFramework="net472" />
+  <package id="Microsoft.Debugging.Platform.SymSrv" version="20220711.1523.0" targetFramework="net472" />
   <package id="Microsoft.SqlServer.XEvent.XELite" version="2021.12.12.2" targetFramework="net472" />
   <package id="Microsoft.TestPlatform" version="17.2.0" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />


### PR DESCRIPTION
* Bump SymSrv and DbgHelp (DbgEng) to 20220711.1523.0
* Specify full path (no wildcards) for Microsoft.TestPlatform