### PR TITLE
Support multiple PDB versions for XML frames

### DIFF
--- a/Engine/DiaUtil.cs
+++ b/Engine/DiaUtil.cs
@@ -6,7 +6,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         internal readonly IDiaDataSource _IDiaDataSource;
         internal readonly IDiaSession _IDiaSession;
         private bool disposedValue = false;
-        public readonly bool HasSourceInfo = false;
+        internal readonly bool HasSourceInfo = false;
         private static readonly object _syncRoot = new();
 
         internal DiaUtil(string pdbName) {
@@ -48,7 +48,8 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         }
 
         /// This function builds up the PDB map, by searching for matched PDBs (based on name) and constructing the DIA session for each
-        internal static bool LocateandLoadPDBs(Dictionary<string, DiaUtil> _diautils, string rootPaths, bool recurse, List<string> moduleNames, bool cachePDB, List<string> modulesToIgnore) {
+        internal static bool LocateandLoadPDBs(Dictionary<string, DiaUtil> _diautils, string rootPaths, bool recurse, Dictionary<string, string> moduleNamesMap, bool cachePDB, List<string> modulesToIgnore) {
+            var moduleNames = moduleNamesMap.Keys;
             // loop through each module, trying to find matched PDB files
             foreach (string currentModule in moduleNames.Where(m => !modulesToIgnore.Contains(m) && !_diautils.ContainsKey(m))) {
                 // we only need to search for the PDB if it does not already exist in our map
@@ -102,6 +103,9 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             string offsetStr = string.Empty;
             if (includeOffset) offsetStr = string.Format(CultureInfo.CurrentCulture, "+{0}", displacement);
             var inlineePrefix = isInLinee ? "(Inline Function) " : string.Empty;
+            // replace any "unique" module names with their original values
+            
+
             return $"{inlineePrefix}{moduleName}!{funcname2}{offsetStr}";
         }
 

--- a/Engine/DiaUtil.cs
+++ b/Engine/DiaUtil.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License - see LICENSE file in this repo.
-using System.Collections.Generic;
-
 namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
     /// Wrapper class around DIA
     internal class DiaUtil {
@@ -69,14 +67,13 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                                 if (foundFiles.Any()) break;
                             } else break;
 
-                            if (!foundFiles.Any() && currPath.EndsWith(currentModule)) { // search for subfolder with PDB GUID as the name
+                            if (currPath.EndsWith(currentModule)) { // search for subfolder with PDB GUID as the name
                                 foundFiles = Directory.EnumerateFiles(currPath, "*.pdb", recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
                                 if (foundFiles.Any()) break;
                             }
                         }
 
-                        // last attempt, fall back to looking for the original module name, but only amongst user-supplied symbol path folder(s)
-                        // TODO add test for this with vcruntime
+                        // if needed, make a last attempt looking for the original module name - but only amongst user-supplied symbol path folder(s)
                         if (!foundFiles.Any()) foreach (var currPath in userSuppliedSymPath.Split(';').Where(p => Directory.Exists(p))) {
                                 if (!currPath.EndsWith(currentModule)) foundFiles = Directory.EnumerateFiles(currPath, moduleNamesMap[currentModule] + ".pdb", recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
                             }

--- a/Engine/DiaUtil.cs
+++ b/Engine/DiaUtil.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License - see LICENSE file in this repo.
+using System.Collections.Generic;
+
 namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
     /// Wrapper class around DIA
     internal class DiaUtil {
@@ -50,51 +52,49 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         /// This function builds up the PDB map, by searching for matched PDBs (based on name) and constructing the DIA session for each
         internal static bool LocateandLoadPDBs(Dictionary<string, DiaUtil> _diautils, string userSuppliedSymPath, string symSrvSymPath, bool recurse, Dictionary<string, string> moduleNamesMap, bool cachePDB, List<string> modulesToIgnore) {
             var completeSymPath = $"{symSrvSymPath};{userSuppliedSymPath}";
-            lock (moduleNamesMap) {
-                var moduleNames = moduleNamesMap.Keys;
-                // loop through each module, trying to find matched PDB files
-                foreach (string currentModule in moduleNames.Where(m => !modulesToIgnore.Contains(m) && !_diautils.ContainsKey(m))) {
-                    // we only need to search for the PDB if it does not already exist in our map
-                    var cachedPDBFile = Path.Combine(Path.GetTempPath(), "SymCache", currentModule + ".pdb");
-                    lock (_syncRoot) {  // the lock is needed to ensure that we do not make multiple copies of PDBs when cachePDB is true
-                        if (!File.Exists(cachedPDBFile)) {
-                            IEnumerable<string> foundFiles = new List<string>();
-                            foreach (var currPath in completeSymPath.Split(';').Where(p => Directory.Exists(p))) {
-                                foundFiles = Directory.EnumerateFiles(currPath, currentModule + ".pdb", recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
-                                if (!foundFiles.Any()) {
-                                    // repeat the search but with a more relaxed filter. this (somewhat hacky) consideration is required
-                                    // for modules like vcruntime140.dll where the PDB name is actually vcruntime140.amd64.pdb
-                                    foundFiles = Directory.EnumerateFiles(currPath, currentModule + ".*.pdb", recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
-                                    if (foundFiles.Any()) break;
-                                } else break;
+            var moduleNames = moduleNamesMap.Keys.ToList();
+            // loop through each module, trying to find matched PDB files
+            foreach (string currentModule in moduleNames.Where(m => !modulesToIgnore.Contains(m) && !_diautils.ContainsKey(m))) {
+                // we only need to search for the PDB if it does not already exist in our map
+                var cachedPDBFile = Path.Combine(Path.GetTempPath(), "SymCache", currentModule + ".pdb");
+                lock (_syncRoot) {  // the lock is needed to ensure that we do not make multiple copies of PDBs when cachePDB is true
+                    if (!File.Exists(cachedPDBFile)) {
+                        IEnumerable<string> foundFiles = new List<string>();
+                        foreach (var currPath in completeSymPath.Split(';').Where(p => Directory.Exists(p))) {
+                            foundFiles = Directory.EnumerateFiles(currPath, currentModule + ".pdb", recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+                            if (!foundFiles.Any()) {
+                                // repeat the search but with a more relaxed filter. this (somewhat hacky) consideration is required
+                                // for modules like vcruntime140.dll where the PDB name is actually vcruntime140.amd64.pdb
+                                foundFiles = Directory.EnumerateFiles(currPath, currentModule + ".*.pdb", recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+                                if (foundFiles.Any()) break;
+                            } else break;
 
-                                if (!foundFiles.Any() && currPath.EndsWith(currentModule)) { // search for subfolder with PDB GUID as the name
-                                    foundFiles = Directory.EnumerateFiles(currPath, "*.pdb", recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
-                                    if (foundFiles.Any()) break;
-                                }
+                            if (!foundFiles.Any() && currPath.EndsWith(currentModule)) { // search for subfolder with PDB GUID as the name
+                                foundFiles = Directory.EnumerateFiles(currPath, "*.pdb", recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+                                if (foundFiles.Any()) break;
                             }
+                        }
 
-                            // last attempt, fall back to looking for the original module name, but only amongst user-supplied symbol path folder(s)
-                            // TODO add test for this with vcruntime
-                            if (!foundFiles.Any()) foreach (var currPath in userSuppliedSymPath.Split(';').Where(p => Directory.Exists(p))) {
+                        // last attempt, fall back to looking for the original module name, but only amongst user-supplied symbol path folder(s)
+                        // TODO add test for this with vcruntime
+                        if (!foundFiles.Any()) foreach (var currPath in userSuppliedSymPath.Split(';').Where(p => Directory.Exists(p))) {
                                 if (!currPath.EndsWith(currentModule)) foundFiles = Directory.EnumerateFiles(currPath, moduleNamesMap[currentModule] + ".pdb", recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
                             }
 
-                            if (foundFiles?.Count() == 1) {  // we need to be sure there is only 1 file which matches
-                                if (cachePDB) File.Copy(foundFiles.First(), cachedPDBFile);
-                                else cachedPDBFile = foundFiles.First();
-                            }
+                        if (foundFiles?.Count() == 1) {  // we need to be sure there is only 1 file which matches
+                            if (cachePDB) File.Copy(foundFiles.First(), cachedPDBFile);
+                            else cachedPDBFile = foundFiles.First();
                         }
                     }
-
-                    if (File.Exists(cachedPDBFile)) {
-                        try {
-                            _diautils.Add(currentModule, new DiaUtil(cachedPDBFile));
-                        } catch (COMException) {
-                            return false;
-                        }
-                    } else if (!modulesToIgnore.Contains(currentModule)) modulesToIgnore.Add(currentModule);
                 }
+
+                if (File.Exists(cachedPDBFile)) {
+                    try {
+                        _diautils.Add(currentModule, new DiaUtil(cachedPDBFile));
+                    } catch (COMException) {
+                        return false;
+                    }
+                } else if (!modulesToIgnore.Contains(currentModule)) modulesToIgnore.Add(currentModule);
             }
             return true;
         }

--- a/Engine/DiaUtil.cs
+++ b/Engine/DiaUtil.cs
@@ -63,7 +63,11 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                                 foundFiles = Directory.EnumerateFiles(currPath, currentModule + ".*.pdb", recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
                             }
 
-                            if (foundFiles.Any()) {
+                            if (!foundFiles.Any() && currPath.EndsWith(currentModule)) { // search for subfolder with PDB GUID as the name
+                                foundFiles = Directory.EnumerateFiles(currPath, "*.pdb", recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+                            }
+
+                            if (foundFiles.Count() == 1) {  // we need to be sure there is only 1 file which matches
                                 if (cachePDB) File.Copy(foundFiles.First(), cachedPDBFile);
                                 else cachedPDBFile = foundFiles.First();
                                 break;

--- a/Engine/ModuleInfoHelper.cs
+++ b/Engine/ModuleInfoHelper.cs
@@ -93,11 +93,11 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                                     lock (syms) {
                                         if (syms.TryGetValue(uniqueModuleName, out var existingEntry)) {
                                             if (Guid.Parse(reader.GetAttribute("guid")).ToString("N") != existingEntry.PDBGuid || int.Parse(reader.GetAttribute("age")) != existingEntry.PDBAge) {
-                                                syms = null;
+                                                syms = null;        // TODO address this cleanly
                                                 return;
                                             }
                                             if (ulong.MinValue == existingEntry.CalculatedModuleBaseAddress) existingEntry.CalculatedModuleBaseAddress = calcBaseAddress;
-                                        } else syms.Add(uniqueModuleName, new Symbol() { PDBName = reader.GetAttribute("pdb").ToLower(), PDBAge = int.Parse(pdbAge), PDBGuid = Guid.Parse(pdbGuid).ToString("N"), CalculatedModuleBaseAddress = calcBaseAddress });
+                                        } else syms.Add(uniqueModuleName, new Symbol() { PDBName = reader.GetAttribute("pdb").ToLower(), ModuleName = moduleName, PDBAge = int.Parse(pdbAge), PDBGuid = Guid.Parse(pdbGuid).ToString("N"), CalculatedModuleBaseAddress = calcBaseAddress });
                                     }
                                     string rvaAsIsOrDerived = null;
                                     if (ulong.MinValue != rvaIfPresent) rvaAsIsOrDerived = rvaAttributeVal;

--- a/Engine/ModuleInfoHelper.cs
+++ b/Engine/ModuleInfoHelper.cs
@@ -89,6 +89,10 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 
                                     lock (syms) {
                                         if (syms.TryGetValue(moduleName, out var existingEntry)) {
+                                            if (Guid.Parse(reader.GetAttribute("guid")).ToString("N") != existingEntry.PDBGuid || int.Parse(reader.GetAttribute("age")) != existingEntry.PDBAge) {
+                                                syms = null;
+                                                return;
+                                            }
                                             if (ulong.MinValue == existingEntry.CalculatedModuleBaseAddress) existingEntry.CalculatedModuleBaseAddress = calcBaseAddress;
                                         } else syms.Add(moduleName, new Symbol() { PDBName = reader.GetAttribute("pdb").ToLower(), PDBAge = int.Parse(reader.GetAttribute("age")), PDBGuid = Guid.Parse(reader.GetAttribute("guid")).ToString("N"), CalculatedModuleBaseAddress = calcBaseAddress });
                                     }

--- a/Engine/ModuleInfoHelper.cs
+++ b/Engine/ModuleInfoHelper.cs
@@ -43,8 +43,8 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                         // check if we have all 3 details
                         if (!string.IsNullOrEmpty(pdbName) && pdbAge != int.MinValue && pdbGuid != Guid.Empty) {
                             lock (syms) {
-                                if (!syms.ContainsKey(moduleName)) syms.Add(moduleName, new Symbol() { ModuleName = moduleName, PDBName = pdbName + ".pdb", PDBAge = pdbAge, PDBGuid = pdbGuid.ToString("N") });
-                                else if (!(syms[moduleName].ModuleName == moduleName && syms[moduleName].PDBName == pdbName + ".pdb" && syms[moduleName].PDBAge == pdbAge && syms[moduleName].PDBGuid == pdbGuid.ToString("N"))) { 
+                                if (!syms.TryGetValue(moduleName, out Symbol existingSym)) syms.Add(moduleName, new Symbol() { ModuleName = moduleName, PDBName = pdbName + ".pdb", PDBAge = pdbAge, PDBGuid = pdbGuid.ToString("N") });
+                                else if (!(existingSym.ModuleName == moduleName && existingSym.PDBName == pdbName + ".pdb" && existingSym.PDBAge == pdbAge && existingSym.PDBGuid == pdbGuid.ToString("N"))) {
                                     anyTaskFailed = true;
                                     return;
                                 }

--- a/Engine/StackResolver.cs
+++ b/Engine/StackResolver.cs
@@ -215,7 +215,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                     sourceInfo = DiaUtil.GetSourceInfo(enumLineNums, pdbHasSourceInfo);
                     Marshal.FinalReleaseComObject(enumLineNums);
                 }
-                var originalModuleName = moduleNamesMap.ContainsKey(moduleName) ? moduleNamesMap[moduleName] : moduleName;
+                var originalModuleName = moduleNamesMap.TryGetValue(moduleName, out string existingModule) ? existingModule : moduleName;
                 if (showInlineFrames && pdbHasSourceInfo && !sourceInfo.Contains("-- WARNING:")) {
                     inlineFrameAndSourceInfo = DiaUtil.ProcessInlineFrames(originalModuleName, useUndecorateLogic, includeOffset, includeSourceInfo, rva, mysym, pdbHasSourceInfo);
                 }

--- a/Engine/StackResolver.cs
+++ b/Engine/StackResolver.cs
@@ -331,6 +331,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                     this.StatusMessage = "Looking for embedded XML-formatted frames and symbol information...";
                     // attempt to check if there are XML-formatted frames each with the related PDB attributes and if so replace those lines with the normalized versions
                     (syms, listOfCallStacks) = await ModuleInfoHelper.ParseModuleInfoXMLAsync(listOfCallStacks, cts);
+                    if (syms == null) return "Unable to determine symbol information from XML frames - this may be caused by multiple PDB versions in the same input.";
                     if (cts.IsCancellationRequested) { StatusMessage = OperationCanceled; PercentComplete = 0; return OperationCanceled; }
                     if (syms.Count() > 0) {
                         // if the user has provided such a list of module info, proceed to actually use dbghelp.dll / symsrv.dll to download thos PDBs and get local paths for them

--- a/Engine/StackResolver.cs
+++ b/Engine/StackResolver.cs
@@ -320,6 +320,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 
                 this.StatusMessage = "Checking for embedded symbol information...";
                 var syms = await ModuleInfoHelper.ParseModuleInfoAsync(listOfCallStacks, cts);
+                if (syms == null) return "Unable to determine symbol information from XML frames - this may be caused by multiple PDB versions in the same input.";
                 if (cts.IsCancellationRequested) { StatusMessage = OperationCanceled; PercentComplete = 0; return OperationCanceled; }
 
                 var symSrvSymPath = string.Empty;
@@ -339,7 +340,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                     }
                 }
 
-                var moduleNamesMap = syms.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ModuleName, StringComparer.OrdinalIgnoreCase); //.Select(kvp => new KeyValuePair<string, string>(kvp.Key, kvp.Value.PDBName));
+                var moduleNamesMap = syms.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.ModuleName, StringComparer.OrdinalIgnoreCase);
 
                 this.StatusMessage = "Resolving callstacks to symbols...";
                 this.globalCounter = 0;

--- a/Engine/Symbol.cs
+++ b/Engine/Symbol.cs
@@ -3,7 +3,7 @@
 namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
     [DataContract] public class Symbol {
         [DataMember(Order = 0)] public string PDBName;
-        [IgnoreDataMember] public string InternalPDBName;
+        [IgnoreDataMember] public string ModuleName;
         [IgnoreDataMember] public string PDBGuid;
         [IgnoreDataMember] public int PDBAge;
         [IgnoreDataMember] public ulong CalculatedModuleBaseAddress;

--- a/Tests/TestCases/downloadsyms.ps1
+++ b/Tests/TestCases/downloadsyms.ps1
@@ -21,6 +21,12 @@ if (-not (test-path $localpath)) {
     dir $localpath
 }
 
+$localpath = "./SourceInformation/vcruntime140.amd64.pdb"
+if (-not (test-path $localpath)) {
+    Invoke-WebRequest -UseBasicParsing -uri ($msdlurl + "vcruntime140.amd64.pdb\AF138C3F293340978883C1071B13375E1/vcruntime140.amd64.pdb") -OutFile $localpath
+    dir $localpath
+}
+
 $onnxpdb = [System.IO.Path]::Combine($PWD, "SourceInformation/onnxruntime.pdb")
 $onnxzipfile = [System.IO.Path]::Combine($PWD, "SourceInformation/onnxruntime-win-x64-1.12.0.zip")
 if (-not (test-path $onnxpdb)) {

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -521,8 +521,8 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "<frame id=\"01\" pdb=\"sqldk.pdb\" age=\"2\" guid=\"1D3FA75E-B355-40E2-87B2-E012D69785DF\" module=\"sqldk.dll\" rva=\"0x3D45D\" />";
 
             var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
-            //var expected = "00 sqldk!XeSosPkg::wait_completed::Publish+476\r\n01 sqldk!SOS_Scheduler::UpdateWaitTimeStats+1186\r\n00 sqldk!XeSosPkg::spinlock_backoff::Publish+425\r\n01 sqldk!SpinlockBase::Sleep+182\r\n";
-            var expected = "Unable to determine symbol information from XML frames - this may be caused by multiple PDB versions in the same input.";
+            var expected = "00 sqldk!XeSosPkg::wait_completed::Publish+476\r\n01 sqldk!SOS_Scheduler::UpdateWaitTimeStats+1186\r\n00 sqldk!XeSosPkg::spinlock_backoff::Publish+425\r\n01 sqldk!SpinlockBase::Sleep+182\r\n";
+            //var expected = "Unable to determine symbol information from XML frames - this may be caused by multiple PDB versions in the same input.";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
 

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -521,7 +521,8 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "<frame id=\"01\" pdb=\"sqldk.pdb\" age=\"2\" guid=\"1D3FA75E-B355-40E2-87B2-E012D69785DF\" module=\"sqldk.dll\" rva=\"0x3D45D\" />";
 
             var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
-            var expected = "00 sqldk!XeSosPkg::wait_completed::Publish+476\r\n01 sqldk!SOS_Scheduler::UpdateWaitTimeStats+1186\r\n00 sqldk!XeSosPkg::spinlock_backoff::Publish+425\r\n01 sqldk!SpinlockBase::Sleep+182\r\n";
+            //var expected = "00 sqldk!XeSosPkg::wait_completed::Publish+476\r\n01 sqldk!SOS_Scheduler::UpdateWaitTimeStats+1186\r\n00 sqldk!XeSosPkg::spinlock_backoff::Publish+425\r\n01 sqldk!SpinlockBase::Sleep+182\r\n";
+            var expected = "Unable to determine symbol information from XML frames - this may be caused by multiple PDB versions in the same input.";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
 

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -699,7 +699,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var pdbPath = string.Empty;
-            var input = @"ntdll+0x9F7E4\r\nKERNELBASE+0x38973\r\nVCRUNTIME140+0xB8F0\r\nntdll+0xA479F\r\nntdll+0x4BEF\r\nntdll+0x89E6\r\nKERNELBASE+0x396C9\r\n" +
+            var input = "ntdll+0x9F7E4\r\nKERNELBASE+0x38973\r\nVCRUNTIME140+0xB8F0\r\nntdll+0xA479F\r\nntdll+0x4BEF\r\nntdll+0x89E6\r\nKERNELBASE+0x396C9\r\n" +
 "\"ntdll.dll\",\"10.0.17763.1490\",2019328,462107166,2009368,\"ntdll.pdb\",\"{C374E059-5793-9B92-6525-386A66A2D3F5}\",0,1\r\n" +
 "\"KERNELBASE.dll\",\"10.0.17763.1518\",2707456,4281343292,2763414,\"kernelbase.pdb\",\"{E77E26E7-D1C4-72BB-2C05-DD17624A9E58}\",0,1\r\n" +
 "\"VCRUNTIME140.dll\",\"14.16.27033.0\",86016,1563486943,105788,\"vcruntime140.amd64.pdb\",\"{AF138C3F-2933-4097-8883-C1071B13375E}\",0,1\r\n";

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -510,6 +510,21 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
 
+        /// End-to-end test with multiple stacks, each with different versions of the module / PDBs
+        [TestMethod][TestCategory("Unit")] public async Task E2ESymSrvXMLFramesWithMultiplePDBVersions() {
+            using var csr = new StackResolver();
+            using var cts = new CancellationTokenSource();
+            var pdbPath = @"srv*https://msdl.microsoft.com/download/symbols";
+            var input = "<frame id=\"00\" pdb=\"sqldk.pdb\" age=\"2\" guid=\"122FC135-ABF2-4465-BA9E-6BE0A6274EB3\" module=\"sqldk.dll\" rva=\"0x106C7C\" />" +
+"<frame id=\"01\" pdb=\"sqldk.pdb\" age=\"2\" guid=\"122FC135-ABF2-4465-BA9E-6BE0A6274EB3\" module=\"sqldk.dll\" rva=\"0x59204\" />\r\n\r\n" +
+"<frame id=\"00\" pdb=\"sqldk.pdb\" age=\"2\" guid=\"1D3FA75E-B355-40E2-87B2-E012D69785DF\" module=\"sqldk.dll\" rva=\"0xFD919\" />" +
+"<frame id=\"01\" pdb=\"sqldk.pdb\" age=\"2\" guid=\"1D3FA75E-B355-40E2-87B2-E012D69785DF\" module=\"sqldk.dll\" rva=\"0x3D45D\" />";
+
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
+            var expected = "00 sqldk!XeSosPkg::wait_completed::Publish+476\r\n01 sqldk!SOS_Scheduler::UpdateWaitTimeStats+1186\r\n00 sqldk!XeSosPkg::spinlock_backoff::Publish+425\r\n01 sqldk!SpinlockBase::Sleep+182\r\n";
+            Assert.AreEqual(expected.Trim(), ret.Trim());
+        }
+
         /// End-to-end test with stacks being resolved based on symbols from symsrv, with XML-encoded input (as is usually seen in clients like SSMS).
         [TestMethod][TestCategory("Unit")] public async Task E2ESymSrvXMLFramesEncoded() {
             using var csr = new StackResolver();

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -437,10 +437,20 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         }
 
         /// Tests the parsing and extraction of PDB details from a set of rows each with commma-separated fields.
-        [TestMethod][TestCategory("Unit")] public async Task ExtractModuleInfoEmptyString() {
+        [TestMethod][TestCategory("Unit")] public async Task ExtractModuleInfoExceptionalCases() {
             using var cts = new CancellationTokenSource();
             var ret = await ModuleInfoHelper.ParseModuleInfoAsync(new List<StackDetails>() { new StackDetails(string.Empty, false) }, cts);
             Assert.AreEqual(ret.Count(), 0);
+            // test for a completely duplicated symbol entry - that's okay
+            ret = await ModuleInfoHelper.ParseModuleInfoAsync(new List<StackDetails>() { new StackDetails("\"ntdll.dll\",\"10.0.19041.662\",2056192,666871280,2084960,\"ntdll.pdb\",\"{1EB9FACB-04C7-3C5D-EA71-60764CD333D0}\",0,1\r\n" +
+"\"ntdll.dll\",\"10.0.19041.662\",2056192,666871280,2084960,\"ntdll.pdb\",\"{1EB9FACB-04C7-3C5D-EA71-60764CD333D0}\",0,1\r\n" +
+"\"kernel32.dll\",\"10.0.19041.662\",774144,1262097423,770204,\"kernel32.pdb\",\"{54448D8E-EFC5-AB3C-7193-D2C7A6DF9008}\",0,1\r\n", false)}, cts);
+            Assert.AreEqual(ret.Count(), 2);
+            // when there is more than one PDB for the same module, fail
+            ret = await ModuleInfoHelper.ParseModuleInfoAsync(new List<StackDetails>() { new StackDetails("\"sqldk.dll\",\"14.0.3192.2\",0,0,0,\"sqldk.pdb\",\"{122FC135-ABF2-4465-BA9E-6BE0A6274EB3}\",0,2\r\n" +
+"\"sqldk.dll\",\"13.0.4001.0\",0,0,0,\"sqldk.pdb\",\"{1D3FA75E-B355-40E2-87B2-E012D69785DF}\",0,2\r\n" +
+"\"kernel32.dll\",\"10.0.19041.662\",774144,1262097423,770204,\"kernel32.pdb\",\"{54448D8E-EFC5-AB3C-7193-D2C7A6DF9008}\",0,1\r\n", false)}, cts);
+            Assert.IsNull(ret);
         }
 
         /// Test obtaining a local path for symbols downloaded from a symbol server.
@@ -556,11 +566,11 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             var input = "Frame = <frame id=\"00\" pdb=\"ntdll.pdb\" age=\"1\" guid=\"C374E059-5793-9B92-6525-386A66A2D3F5\" module=\"ntdll.dll\" rva=\"0x9F7E4\" />        \r\n" +
 "Frame = <frame id=\"01\" pdb=\"kernelbase.pdb\" age=\"1\" guid=\"E77E26E7-D1C4-72BB-2C05-DD17624A9E58\" module=\"KERNELBASE.dll\" rva=\"0x38973\" />                          \n" +
 "Frame = <frame id=\"02\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-\r\nd905ad930ee6\" module=\"sqldk.dll\" rva=\"0x40609\" />                                    \r\n" +
-"<frame id=\"03\" pdb=\"vcruntime140.amd64.pdb\" age=\"1\" guid=\"AF138C3F-2933-4097-8883-C1071B13375E\" module=\"VCRUNTIME140.dll\" rva=\"0xB8F0\" />\r\n" +
+"VCRUNTIME140+0xB8F0\r\n" +
 "Frame = <frame id=\"04\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-d905ad930ee6\" module=\"sqldk.dll\" rva=\"0x2249f\" />                                    \n" +
 "Frame = <frame id=\"05\" pdb=\"onnxruntime.pdb\" age=\"1\" guid=\"D1106301-B61B-4655-BFAC-DC1EA8911A7E\" module=\"onnxruntime.dll\" rva=\"0x4fd50\" />";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+                        var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n03 VCRUNTIME140!__C_specific_handler+160	(d:\\agent\\_work\\2\\s\\src\\vctools\\crt\\vcruntime\\src\\eh\\riscchandler.cpp:290)\r\n04 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349\r\n05 onnxruntime!onnxruntime::InferenceSession::Initialize+0\t(D:\\a\\_work\\1\\s\\onnxruntime\\core\\session\\inference_session.cc:1238)";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -402,18 +402,22 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 
             var syms = result.Item1;
             Assert.AreEqual(4, syms.Count());
-            Assert.AreEqual("ntdll.pdb", syms["ntdll"].PDBName);
-            Assert.AreEqual("C374E05957939B926525386A66A2D3F5", syms["ntdll"].PDBGuid, ignoreCase: true);
-            Assert.AreEqual(1, syms["ntdll"].PDBAge);
-            Assert.AreEqual("kernelbase.pdb", syms["KERNELBASE"].PDBName);
-            Assert.AreEqual("E77E26E7D1C472BB2C05DD17624A9E58", syms["KERNELBASE"].PDBGuid, ignoreCase: true);
-            Assert.AreEqual(1, syms["KERNELBASE"].PDBAge);
-            Assert.AreEqual("sqldk.pdb", syms["sqldk"].PDBName);
-            Assert.AreEqual("6a1934433512464b8b8ed905ad930ee6", syms["sqldk"].PDBGuid, ignoreCase: true);
-            Assert.AreEqual(2, syms["sqldk"].PDBAge);
-            Assert.AreEqual("vcruntime140.amd64.pdb", syms["VCRUNTIME140"].PDBName);
-            Assert.AreEqual("AF138C3F293340978883C1071B13375E", syms["VCRUNTIME140"].PDBGuid, ignoreCase: true);
-            Assert.AreEqual(1, syms["VCRUNTIME140"].PDBAge);
+            Assert.AreEqual("ntdll.pdb", syms["C374E05957939B926525386A66A2D3F51"].PDBName);
+            Assert.AreEqual("C374E05957939B926525386A66A2D3F5", syms["C374E05957939B926525386A66A2D3F51"].PDBGuid);
+            Assert.AreEqual("ntdll", syms["C374E05957939B926525386A66A2D3F51"].ModuleName);
+            Assert.AreEqual(1, syms["C374E05957939B926525386A66A2D3F51"].PDBAge);
+            Assert.AreEqual("kernelbase.pdb", syms["E77E26E7D1C472BB2C05DD17624A9E581"].PDBName);
+            Assert.AreEqual("E77E26E7D1C472BB2C05DD17624A9E58", syms["E77E26E7D1C472BB2C05DD17624A9E581"].PDBGuid);
+            Assert.AreEqual("KERNELBASE", syms["E77E26E7D1C472BB2C05DD17624A9E581"].ModuleName);
+            Assert.AreEqual(1, syms["E77E26E7D1C472BB2C05DD17624A9E581"].PDBAge);
+            Assert.AreEqual("sqldk.pdb", syms["6A1934433512464B8B8ED905AD930EE62"].PDBName);
+            Assert.AreEqual("6A1934433512464B8B8ED905AD930EE6", syms["6A1934433512464B8B8ED905AD930EE62"].PDBGuid);
+            Assert.AreEqual("sqldk", syms["6A1934433512464B8B8ED905AD930EE62"].ModuleName);
+            Assert.AreEqual(2, syms["6A1934433512464B8B8ED905AD930EE62"].PDBAge);
+            Assert.AreEqual("vcruntime140.amd64.pdb", syms["AF138C3F293340978883C1071B13375E1"].PDBName);
+            Assert.AreEqual("AF138C3F293340978883C1071B13375E", syms["AF138C3F293340978883C1071B13375E1"].PDBGuid);
+            Assert.AreEqual("VCRUNTIME140", syms["AF138C3F293340978883C1071B13375E1"].ModuleName);
+            Assert.AreEqual(1, syms["AF138C3F293340978883C1071B13375E1"].PDBAge);
         }
 
         /// Tests the parsing and extraction of PDB details from a set of rows each with XML frames. Some of those XML frames do not have sym info or RVA included.
@@ -423,11 +427,13 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             var result = await ModuleInfoHelper.ParseModuleInfoXMLAsync(new List<StackDetails> { input }, cts);
 
             var syms = result.Item1;
+            var symKey = "6A1934433512464B8B8ED905AD930EE62";
             Assert.AreEqual(1, syms.Count);
-            Assert.AreEqual("sqldk.pdb", syms["sqldk"].PDBName);
-            Assert.AreEqual("6a1934433512464b8b8ed905ad930ee6", syms["sqldk"].PDBGuid, ignoreCase: true);
-            Assert.AreEqual(2, syms["sqldk"].PDBAge);
-            Assert.AreEqual((ulong)0x100400000, syms["sqldk"].CalculatedModuleBaseAddress);
+            Assert.AreEqual("sqldk.pdb", syms[symKey].PDBName);
+            Assert.AreEqual("sqldk", syms[symKey].ModuleName);
+            Assert.AreEqual("6a1934433512464b8b8ed905ad930ee6", syms[symKey].PDBGuid, ignoreCase: true);
+            Assert.AreEqual(2, syms[symKey].PDBAge);
+            Assert.AreEqual((ulong)0x100400000, syms[symKey].CalculatedModuleBaseAddress);
         }
 
         /// Tests the parsing and extraction of PDB details from a set of rows each with commma-separated fields.


### PR DESCRIPTION
- Add tests for multiple PDB versions in XML frames and also in CSV metadata
- Uniquely identify module names based on PDB GUID+age
- Return error when input has info about multiple PDB versions in CSV metadata
- Separate user-supplied and generated sympaths
- Infer sym info for truncated frames from prior ones
- Preserve original module name for final output

