### PR TITLE
Improve symbol re-lookup implementation

### DIFF
--- a/Engine/StackDetails.cs
+++ b/Engine/StackDetails.cs
@@ -30,7 +30,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                 // from the SSMS XEvent window (copying the callstack field without opening it in its own viewer)
                 // in that case, space is a valid delimiter, and we need to support that as an option
                 var delims = this._framesOnSingleLine ? new char[] { '\t', '\n' } : new char[] { '\n' };
-                if (!this._relookupSource) delims = delims.Append(' ').ToArray();
+                if (!this._relookupSource && this._framesOnSingleLine) delims = delims.Append(' ').ToArray();
                 return this._callStack.Replace("\r", string.Empty).Split(delims);
             }
         }

--- a/Engine/StackDetails.cs
+++ b/Engine/StackDetails.cs
@@ -8,11 +8,13 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         private string _annotation, _callStack, _resolvedStack;
         private readonly string _stackKey;
         private readonly bool _framesOnSingleLine;
+        private readonly bool _relookupSource;
 
-        public StackDetails(string callStack, bool framesOnSingleLine, string annotation = null, string stackKey = null) {
+        public StackDetails(string callStack, bool framesOnSingleLine, string annotation = null, string stackKey = null, bool relookupSource = false) {
             this._annotation = annotation;
             this._stackKey = stackKey;
             this._framesOnSingleLine = framesOnSingleLine;
+            this._relookupSource = relookupSource;
             this._callStack = System.Net.WebUtility.HtmlDecode(framesOnSingleLine ? Regex.Replace(callStack, @"\s{2,}", " ") : callStack);
             _stackKey = stackKey;
         }
@@ -27,7 +29,8 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                 // sometimes we see call stacks which are arranged horizontally (this typically is seen when copy-pasting directly
                 // from the SSMS XEvent window (copying the callstack field without opening it in its own viewer)
                 // in that case, space is a valid delimiter, and we need to support that as an option
-                var delims = this._framesOnSingleLine ? new char[3] { ' ', '\t', '\n' } : new char[1] { '\n' };
+                var delims = this._framesOnSingleLine ? new char[] { '\t', '\n' } : new char[] { '\n' };
+                if (!this._relookupSource) delims = delims.Append(' ').ToArray();
                 return this._callStack.Replace("\r", string.Empty).Split(delims);
             }
         }

--- a/Engine/StackResolver.cs
+++ b/Engine/StackResolver.cs
@@ -357,9 +357,8 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                     relookupSource, includeOffsets, cachePDB, cts));
 
                 this.StatusMessage = "Waiting for tasks to finish...";
-                while (true) {
-                    if (Task.WaitAll(tasks.ToArray(), OperationWaitIntervalMilliseconds)) break;
-                }
+                while (true) if (Task.WaitAll(tasks.ToArray(), OperationWaitIntervalMilliseconds)) break;
+
                 if (cts.IsCancellationRequested) { StatusMessage = OperationCanceled; PercentComplete = 0; return OperationCanceled; }
                 this.StatusMessage = "Done with symbol resolution, finalizing output...";
                 this.globalCounter = 0;
@@ -550,10 +549,8 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                 }
 
                 // cleanup any older COM objects
-                if (_diautils != null) {
-                    foreach (var diautil in _diautils.Values) diautil.Dispose();
-                    _diautils.Clear();
-                }
+                _diautils?.Values.ToList().ForEach(diautil => diautil.Dispose());
+                _diautils?.Clear();
 
                 SafeNativeMethods.DestroyActivationContext();
             });

--- a/Engine/StackResolver.cs
+++ b/Engine/StackResolver.cs
@@ -410,6 +410,8 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             });
         }
 
+        public async Task<List<StackDetails>> GetListofCallStacksAsync(string inputCallstackText, bool framesOnSingleLine, CancellationTokenSource cts) => await GetListofCallStacksAsync(inputCallstackText, framesOnSingleLine, false, cts);
+
         /// <summary>
         /// Gets a list of StackDetails objects based on the textual callstack input
         /// </summary>

--- a/Engine/StackResolver.cs
+++ b/Engine/StackResolver.cs
@@ -207,8 +207,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                     }
                 }
 
-                if (mysym == null) // if all attempts to locate a matching symbol have failed, return null
-                    return null;
+                if (mysym == null) return null; // if all attempts to locate a matching symbol have failed, return null
 
                 string sourceInfo = string.Empty;   // try to find if we have source and line number info and include it based on the param
                 string inlineFrameAndSourceInfo = string.Empty; // Process inline functions, but only if private PDBs are in use

--- a/Engine/StackResolver.cs
+++ b/Engine/StackResolver.cs
@@ -62,10 +62,9 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         public bool IsInputSingleLine(string text, string patternsToTreatAsMultiline) {
             if (Regex.Match(text, patternsToTreatAsMultiline).Success) return false;
             text = System.Net.WebUtility.HtmlDecode(text);  // decode XML markup if present
-            if (!(Regex.Match(text, "Histogram").Success || Regex.Match(text, @"\<frame", RegexOptions.IgnoreCase).Success) && !text.Replace("\r", string.Empty).Trim().Contains('\n')) {
-                if (rgxAlreadySymbolizedFrame.Matches(text).Count > 1 || rgxModuleOffsetFrame.Matches(text).Count > 1)
-                    return true; // not a histogram, not already a single-line input frame, and does not have any newlines, so is single-line
-            }
+            if (!(Regex.Match(text, "Histogram").Success || Regex.Match(text, @"\<frame", RegexOptions.IgnoreCase).Success) && !text.Replace("\r", string.Empty).Trim().Contains('\n') && (rgxAlreadySymbolizedFrame.Matches(text).Count > 1 || rgxModuleOffsetFrame.Matches(text).Count > 1))
+                return true; // not a histogram, not already a single-line input frame, and does not have any newlines, so is single-line
+
             if (!Regex.Match(text, @"\<frame").Success) {   // input does not have "XML frames", so keep looking...
                 if (Regex.Match(text, @"\<Slot.+\<\/Slot\>").Success) return true;  // the content within a given histogram slot is on a single line, so is single-line
                 if (Regex.Match(text, @"0x.+0x.+").Success) return true;

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -85,7 +85,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 
             List<StackDetails> allStacks = null;
             using (BackgroundCTS = new CancellationTokenSource()) {
-                var allStacksTask = this._resolver.GetListofCallStacksAsync(callStackInput.Text, FramesOnSingleLine.Checked, BackgroundCTS);
+                var allStacksTask = this._resolver.GetListofCallStacksAsync(callStackInput.Text, FramesOnSingleLine.Checked, RelookupSource.Checked, BackgroundCTS);
                 this.MonitorBackgroundTask(allStacksTask);
                 allStacks = allStacksTask.Result;
             }

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var pdbPath = @"..\..\..\Tests\TestCases\TestBlockResolution";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Return Addr: 00007FF830D4CDA4 Module(KERNELBASE+000000000009CDA4)", false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Return Addr: 00007FF830D4CDA4 Module(KERNELBASE+000000000009CDA4)", false, false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
             Assert.AreEqual("KERNELBASE!SignalObjectAndWait+147716", ret.Trim());
         }
 
@@ -64,7 +64,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var dllPaths = new List<string> { Path.GetTempPath(), @"..\..\..\Tests\TestCases\TestOrdinal", Path.GetTempPath() };    // use different paths to validate the multi-path handling
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("ntdll!Ordinal298+00000000000004A5\r\n00007FF818405E70      Module(ntdll+0000000000091735) (Ordinal298 + 00000000000004A5)", false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, dllPaths, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("ntdll!Ordinal298+00000000000004A5\r\n00007FF818405E70      Module(ntdll+0000000000091735) (Ordinal298 + 00000000000004A5)", false, false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, dllPaths, false, false, false, true, false, false, null, cts);
             Assert.AreEqual("ntdll!NtOpenKeyEx+5\r\nntdll!NtOpenKeyEx+5", ret.Trim());
         }
 
@@ -72,7 +72,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         [TestMethod][TestCategory("Unit")] public async Task RegularSymbolHexOffset() {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("sqldk +0x40609\r\nsqldk+40609", false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("sqldk +0x40609\r\nsqldk+40609", false, false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, null, cts);
             var expectedSymbol = "sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644";
             Assert.AreEqual(expectedSymbol + Environment.NewLine + expectedSymbol, ret.Trim());
         }
@@ -81,7 +81,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         [TestMethod][TestCategory("Unit")] public async Task CorruptPDBWarning() {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("sqldk+40609", false, cts), @"..\..\..\Tests\TestCases\CorruptPDB", false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("sqldk+40609", false, false, cts), @"..\..\..\Tests\TestCases\CorruptPDB", false, null, false, false, false, true, false, false, null, cts);
             Assert.IsTrue(ret.StartsWith($"sqldk+40609 {StackResolver.WARNING_PREFIX}"));
         }
 
@@ -90,7 +90,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             Assert.IsTrue(csr.ProcessBaseAddresses(@"c:\mssql\binn\sqldk.dll 00000001`00400000"));
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("0x000000010042249f", false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("0x000000010042249f", false, false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, null, cts);
             var expectedSymbol = "sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349";
             Assert.AreEqual(expectedSymbol, ret.Trim());
         }
@@ -100,7 +100,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var cts = new CancellationTokenSource();
             var moduleAddresses = "c:\\mssql\\binn\\sqldk.dll 00000001`00400000\r\nc:\\windows\\temp\\sqldk.dll 00000001`00400000";
             Assert.IsFalse(csr.ProcessBaseAddresses(moduleAddresses));
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("0x000000010042249f\r\nsqldk+0x40609", false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("0x000000010042249f\r\nsqldk+0x40609", false, false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, null, cts);
             Assert.AreEqual("0x000000010042249f\r\nsqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644", ret.Trim());
         }
 
@@ -111,7 +111,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             Assert.IsTrue(csr.ProcessBaseAddresses(@"c:\mssql\binn\sqldk.dll 00000001`00400000"));
             var timer = new System.Diagnostics.Stopwatch();
             timer.Start();
-            await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(PrepareLargeXEventInput(), false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()), cts);
+            await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(PrepareLargeXEventInput(), false, false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()), cts);
             timer.Stop();
             Assert.IsTrue(timer.Elapsed.TotalSeconds < 45 * 60);  // 45 minutes max on GitHub hosted DSv2 runner (2 vCPU, 7 GiB RAM).
         }
@@ -199,7 +199,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         [TestMethod][TestCategory("Unit")] public async Task RegularSymbolHexOffsetNoOutputOffset() {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("sqldk+0x40609", false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, false, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("sqldk+0x40609", false, false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, false, false, false, null, cts);
             var expectedSymbol = "sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode";
             Assert.AreEqual(expectedSymbol, ret.Trim());
         }
@@ -210,7 +210,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         [TestMethod][TestCategory("Unit")] public async Task RegularSymbolHexOffsetNoOutputOffsetWithFrameNums() {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("00 sqldk+0x40609", false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, false, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("00 sqldk+0x40609", false, false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, false, false, false, null, cts);
             var expectedSymbol = "00 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode";
             Assert.AreEqual(expectedSymbol, ret.Trim());
         }
@@ -223,7 +223,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             Assert.AreEqual(550, ret.Item1);
             Assert.IsTrue(csr.ProcessBaseAddresses(File.ReadAllText(@"..\..\..\Tests\TestCases\ImportXEL\xe_wait_base_addresses.txt")));
             var pdbPath = @"..\..\..\Tests\TestCases\sqlsyms\14.0.3192.2\x64";
-            var symres = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(ret.Item2, false, cts), pdbPath, false, null, false, false, false, false, false, true, null, cts);
+            var symres = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(ret.Item2, false, false, cts), pdbPath, false, null, false, false, false, false, false, true, null, cts);
             Assert.IsTrue(symres.Contains("sqldk!XeSosPkg::wait_completed::Publish\r\nsqldk!SOS_Scheduler::UpdateWaitTimeStats\r\nsqldk!SOS_Task::PostWait\r\nsqllang!SOS_Task::Sleep\r\nsqllang!YieldAndCheckForAbort\r\nsqllang!OptimizerUtil::YieldAndCheckForMemoryAndAbort\r\nsqllang!OptTypeVRSetArray::IFindSet\r\nsqllang!CConstraintProp::FEquivalent\r\nsqllang!CJoinEdge::FConstrainsColumnSolvably\r\nsqllang!CStCollOuterJoin::CardForColumns\r\nsqllang!CStCollGroupBy::CStCollGroupBy\r\nsqllang!CCardFrameworkSQL12::CardDistinct\r\nsqllang!CCostUtils::CalcLoopJoinCachedInfo\r\nsqllang!CCostUtils::PcctxLoopJoinHelper\r\nsqllang!COpArg::PcctxCalculateNormalizeCtx\r\nsqllang!CTask_OptInputs::Perform\r\nsqllang!CMemo::ExecuteTasks\r\nsqllang!CMemo::PerformOptimizationStage\r\nsqllang!CMemo::OptimizeQuery\r\nsqllang!COptContext::PexprSearchPlan\r\nsqllang!COptContext::PcxteOptimizeQuery\r\nsqllang!COptContext::PqteOptimizeWrapper\r\nsqllang!PqoBuild\r\nsqllang!CStmtQuery::InitQuery"));
         }
 
@@ -233,7 +233,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var pdbPath = @"..\..\..\Tests\TestCases\SourceInformation";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000+17f27", false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000+17f27", false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             Assert.AreEqual("Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143\t(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxPkgPnp.hpp:4127)", ret.Trim());
         }
 
@@ -243,7 +243,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var pdbPath = @"..\..\..\Tests\TestCases\SourceInformation";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000+17f27", false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000+17f27", false, false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
             Assert.AreEqual("Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143", ret.Trim());
         }
 
@@ -253,7 +253,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var pdbPath = @"..\..\..\Tests\TestCases\SourceInformation";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143", false, cts), pdbPath, false, null, false, true, true, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143", false, true, cts), pdbPath, false, null, false, true, true, true, false, false, null, cts);
             Assert.AreEqual("Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143\t(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxPkgPnp.hpp:4127)", ret.Trim());
         }
 
@@ -286,7 +286,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             csr.ProcessBaseAddresses(File.ReadAllText(@"..\..\..\Tests\TestCases\ImportXEL\base_addresses.txt"));
             Assert.AreEqual(20, csr.LoadedModules.Count);
             var pdbPath = @"..\..\..\Tests\TestCases\sqlsyms\13.0.4001.0\x64";
-            var symres = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(ret.Item2, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var symres = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(ret.Item2, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             Assert.IsTrue(symres.Contains("sqldk!XeSosPkg::spinlock_backoff::Publish+425\r\nsqldk!SpinlockBase::Sleep+182\r\nsqlmin!Spinlock<143,7,1>::SpinToAcquireWithExponentialBackoff+363\r\nsqlmin!lck_lockInternal+2042\r\nsqlmin!MDL::LockGenericLocal+382\r\nsqlmin!MDL::LockGenericIdsLocal+101\r\nsqlmin!CMEDCacheEntryFactory::GetProxiedCacheEntryById+263\r\nsqlmin!CMEDProxyDatabase::GetOwnerByOwnerId+122\r\nsqllang!CSECAccessAuditBase::SetSecurable+427\r\nsqllang!CSECManager::_AccessCheck+151\r\nsqllang!CSECManager::AccessCheck+2346\r\nsqllang!FHasEntityPermissionsWithAuditState+1505\r\nsqllang!FHasEntityPermissions+165\r\nsqllang!CSQLObject::FPostCacheLookup+2562\r\nsqllang!CSQLSource::Transform+2194\r\nsqllang!CSQLSource::Execute+944\r\nsqllang!CStmtExecProc::XretLocalExec+622\r\nsqllang!CStmtExecProc::XretExecExecute+1153\r\nsqllang!CXStmtExecProc::XretExecute+56\r\nsqllang!CMsqlExecContext::ExecuteStmts<1,1>+1037\r\nsqllang!CMsqlExecContext::FExecute+2718\r\nsqllang!CSQLSource::Execute+2435\r\nsqllang!process_request+3681\r\nsqllang!process_commands_internal+735"));
         }
 
@@ -297,7 +297,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             var ret = await csr.ExtractFromXELAsync(new[] { @"..\..\..\Tests\TestCases\ImportXEL\xe_wait_completed_0_132353446563350000.xel" }, false, new List<string>(new String[] { "callstack" }), cts);
             Assert.AreEqual(550, ret.Item1);
             Assert.IsTrue(ret.Item2.Contains("Tests\\TestCases\\ImportXEL\\xe_wait_completed_0_132353446563350000.xel, UTC: 2020-05-30 20:37:36.3626428, UUID: 992caa1d-ef90-4278-9821-ebdd0180db0d\"><action name='callstack'><value><![CDATA[0x00007FFAF2BD6C7C"));
-            var res = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(ret.Item2, false, cts), string.Empty, false, null, false, false, false, false, false, false, null, cts);
+            var res = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(ret.Item2, false, false, cts), string.Empty, false, null, false, false, false, false, false, false, null, cts);
             Assert.IsTrue(res.StartsWith(@"Event key: File: ..\..\..\Tests\TestCases\ImportXEL\xe_wait_completed_0_132353446563350000.xel, UTC: 2020-05-30 20:37:36.3626428, UUID: 992caa1d-ef90-4278-9821-ebdd0180db0d"));
         }
 
@@ -330,7 +330,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             csr.ProcessBaseAddresses(File.ReadAllText(@"..\..\..\Tests\TestCases\ImportXEL\base_addresses.txt"));
             var pdbPath = @"..\..\..\Tests\TestCases\sqlsyms\13.0.4001.0\x64";
             var callStack = @"callstack	          0x00007FFEABD0D919        0x00007FFEABC4D45D      0x00007FFEAC0F7EE0  0x00007FFEAC0F80CF  0x00007FFEAC1EE447  0x00007FFEAC1EE6F5  0x00007FFEAC1D48B0  0x00007FFEAC71475A  0x00007FFEA9A708F1  0x00007FFEA9991FB9  0x00007FFEA9993D21  0x00007FFEA99B59F1  0x00007FFEA99B5055  0x00007FFEA99B2B8F  0x00007FFEA9675AD1  0x00007FFEA9671EFB  0x00007FFEAA37D83D  0x00007FFEAA37D241  0x00007FFEAA379F98  0x00007FFEA96719CA  0x00007FFEA9672933  0x00007FFEA9672041  0x00007FFEA967A82B  0x00007FFEA9681542  ";
-            var symres = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(callStack, true, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
+            var symres = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(callStack, true, false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
             Assert.AreEqual("callstack\r\nsqldk!XeSosPkg::spinlock_backoff::Publish+425\r\nsqldk!SpinlockBase::Sleep+182\r\nsqlmin!Spinlock<143,7,1>::SpinToAcquireWithExponentialBackoff+363\r\nsqlmin!lck_lockInternal+2042\r\nsqlmin!MDL::LockGenericLocal+382\r\nsqlmin!MDL::LockGenericIdsLocal+101\r\nsqlmin!CMEDCacheEntryFactory::GetProxiedCacheEntryById+263\r\nsqlmin!CMEDProxyDatabase::GetOwnerByOwnerId+122\r\nsqllang!CSECAccessAuditBase::SetSecurable+427\r\nsqllang!CSECManager::_AccessCheck+151\r\nsqllang!CSECManager::AccessCheck+2346\r\nsqllang!FHasEntityPermissionsWithAuditState+1505\r\nsqllang!FHasEntityPermissions+165\r\nsqllang!CSQLObject::FPostCacheLookup+2562\r\nsqllang!CSQLSource::Transform+2194\r\nsqllang!CSQLSource::Execute+944\r\nsqllang!CStmtExecProc::XretLocalExec+622\r\nsqllang!CStmtExecProc::XretExecExecute+1153\r\nsqllang!CXStmtExecProc::XretExecute+56\r\nsqllang!CMsqlExecContext::ExecuteStmts<1,1>+1037\r\nsqllang!CMsqlExecContext::FExecute+2718\r\nsqllang!CSQLSource::Execute+2435\r\nsqllang!process_request+3681\r\nsqllang!process_commands_internal+735", symres.Trim());
         }
 
@@ -340,7 +340,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var pdbPath = @"..\..\..\Tests\TestCases\SourceInformation";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000+17f27", false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000+17f27", false, false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
             Assert.AreEqual(
                 "(Inline Function) Wdf01000!Mx::MxLeaveCriticalRegion+12	(minkernel\\wdf\\framework\\shared\\inc\\primitives\\km\\MxGeneralKm.h:198)\r\n(Inline Function) Wdf01000!FxWaitLockInternal::ReleaseLock+62	(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxWaitLock.hpp:305)\r\n(Inline Function) Wdf01000!FxEnumerationInfo::ReleaseParentPowerStateLock+62	(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxPkgPnp.hpp:510)\r\nWdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143	(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxPkgPnp.hpp:4127)",
                 ret.Trim());
@@ -359,7 +359,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             for (int frameNum = 0; frameNum < 1000; frameNum++) {
                 callstackInput.AppendLine($"Wdf01000+{rng.Next(0, 1000000)}");
             }
-            await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(callstackInput.ToString(), false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
+            await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(callstackInput.ToString(), false, false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
             // We do not need to check anything; the criteria for the test passing is that the call did not throw an unhandled exception
         }
 
@@ -369,7 +369,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var pdbPath = @"..\..\..\Tests\TestCases\SourceInformation";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000+17f27", false, cts), pdbPath, false, null, false, false, false, true, true, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000+17f27", false, false, cts), pdbPath, false, null, false, false, false, true, true, false, null, cts);
             Assert.AreEqual("(Inline Function) Wdf01000!Mx::MxLeaveCriticalRegion+12\r\n(Inline Function) Wdf01000!FxWaitLockInternal::ReleaseLock+62\r\n(Inline Function) Wdf01000!FxEnumerationInfo::ReleaseParentPowerStateLock+62\r\nWdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143", ret.Trim());
         }
 
@@ -377,7 +377,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var pdbPath = @"..\..\..\Tests\TestCases\SourceInformation;..\..\..\Tests\TestCases\TestOrdinal";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("00 sqldk+0x40609\r\n01 Wdf01000+17f27\r\n02 sqldk+0x40609", false, cts), pdbPath, false, null, false, false, false, true, true, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("00 sqldk+0x40609\r\n01 Wdf01000+17f27\r\n02 sqldk+0x40609", false, false, cts), pdbPath, false, null, false, false, false, true, true, false, null, cts);
             Assert.AreEqual("00 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n01 (Inline Function) Wdf01000!Mx::MxLeaveCriticalRegion+12\r\n02 (Inline Function) Wdf01000!FxWaitLockInternal::ReleaseLock+62\r\n03 (Inline Function) Wdf01000!FxEnumerationInfo::ReleaseParentPowerStateLock+62\r\n04 Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143\r\n05 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644", ret.Trim());
         }
 
@@ -488,9 +488,9 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "\r\n\"ntdll.dll\",\"10.0.17763.1490\",2019328,462107166,2009368,\"ntdll.pdb\",\"{C374E059-5793-9B92-6525-386A66A2D3F5}\",0,1\r\n" +
 "\"KERNELBASE.dll\",\"10.0.17763.1518\",2707456,4281343292,2763414,\"kernelbase.pdb\",\"{E77E26E7-D1C4-72BB-2C05-DD17624A9E58}\",0,1\r\n" +
 "\"VCRUNTIME140.dll\",\"14.16.27033.0\",86016,1563486943,105788,\"vcruntime140.amd64.pdb\",\"{AF138C3F-2933-4097-8883-C1071B13375E}\",0,1";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), @"https://msdl.microsoft.com/download/symbols", false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), @"https://msdl.microsoft.com/download/symbols", false, null, false, true, false, true, false, false, null, cts);
             Assert.AreEqual(expected.Trim(), ret.Trim());
-            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), @"srv*https://msdl.microsoft.com/download/symbols", false, null, false, true, false, true, false, false, null, cts);
+            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), @"srv*https://msdl.microsoft.com/download/symbols", false, null, false, true, false, true, false, false, null, cts);
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
 
@@ -500,7 +500,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var cts = new CancellationTokenSource();
             var pdbPath = @"srv*https://msdl.microsoft.com/download/symbols";
             var input = "<frame id=\"00\" pdb=\"ntdll.pdb\" age=\"1\" guid=\"C374E059-5793-9B92-6525-386A66A2D3F5\" module=\"ntdll.dll\" rva=\"0x9F7E4\" />";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = @"00 ntdll!NtWaitForSingleObject+20";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -516,7 +516,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "<frame id=\"03\" pdb=\"vcruntime140.amd64.pdb\" age=\"1\" guid=\"AF138C3F-2933-4097-8883-C1071B13375E\" module=\"VCRUNTIME140.dll\" rva=\"0xB8F0\" />\r\n" +
 "Frame = <frame id=\"04\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-d905ad930ee6\" module=\"sqldk.dll\" rva=\"0x2249f\" />                                    \n";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n03 VCRUNTIME140!__C_specific_handler+160	(d:\\agent\\_work\\2\\s\\src\\vctools\\crt\\vcruntime\\src\\eh\\riscchandler.cpp:290)\r\n04 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -532,7 +532,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "<frame id=\"00\" pdb=\"ntdll.pdb\" age=\"1\" guid=\"C374E059-5793-9B92-6525-386A66A2D3F5\" module=\"ntdll.dll\" rva=\"0x9F7E4\" />" +
 "<frame id=\"01\" pdb=\"kernelbase.pdb\" age=\"1\" guid=\"E77E26E7-D1C4-72BB-2C05-DD17624A9E58\" module=\"KERNELBASE.dll\" rva=\"0x38973\" />";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
             var expected = "00 ntdll!NtWaitForSingleObject+20\r\n01 (Inline Function) Wdf01000!Mx::MxLeaveCriticalRegion+12	(minkernel\\wdf\\framework\\shared\\inc\\primitives\\km\\MxGeneralKm.h:198)\r\n02 (Inline Function) Wdf01000!FxWaitLockInternal::ReleaseLock+62	(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxWaitLock.hpp:305)\r\n03 (Inline Function) Wdf01000!FxEnumerationInfo::ReleaseParentPowerStateLock+62	(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxPkgPnp.hpp:510)\r\n04 Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143	(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxPkgPnp.hpp:4127)\r\n05 KERNELBASE!WaitForSingleObjectEx+147\r\n00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -547,7 +547,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "<frame id=\"00\" pdb=\"sqldk.pdb\" age=\"2\" guid=\"1D3FA75E-B355-40E2-87B2-E012D69785DF\" module=\"sqldk.dll\" rva=\"0xFD919\" />" +
 "<frame id=\"01\" pdb=\"sqldk.pdb\" age=\"2\" guid=\"1D3FA75E-B355-40E2-87B2-E012D69785DF\" module=\"sqldk.dll\" rva=\"0x3D45D\" />";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
             var expected = "00 sqldk!XeSosPkg::wait_completed::Publish+476\r\n01 sqldk!SOS_Scheduler::UpdateWaitTimeStats+1186\r\n00 sqldk!XeSosPkg::spinlock_backoff::Publish+425\r\n01 sqldk!SpinlockBase::Sleep+182\r\n";
             //var expected = "Unable to determine symbol information from XML frames - this may be caused by multiple PDB versions in the same input.";
             Assert.AreEqual(expected.Trim(), ret.Trim());
@@ -564,7 +564,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "&lt;frame id=\"03\" pdb=\"vcruntime140.amd64.pdb\" age=\"1\" guid=\"AF138C3F-2933-4097-8883-C1071B13375E\" module=\"VCRUNTIME140.dll\" rva=\"0xB8F0\" /&gt;" +
 "&lt;frame id=\"04\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-d905ad930ee6\" module=\"sqldk.dll\" rva=\"0x2249f\" /&gt;";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n03 VCRUNTIME140!__C_specific_handler+160	(d:\\agent\\_work\\2\\s\\src\\vctools\\crt\\vcruntime\\src\\eh\\riscchandler.cpp:290)\r\n04 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -581,7 +581,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "Frame = <frame id=\"04\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-d905ad930ee6\" module=\"sqldk.dll\" rva=\"0x2249f\" />                                    \n" +
 "Frame = <frame id=\"05\" pdb=\"onnxruntime.pdb\" age=\"1\" guid=\"D1106301-B61B-4655-BFAC-DC1EA8911A7E\" module=\"onnxruntime.dll\" rva=\"0x4fd50\" />";
 
-                        var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+                        var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n03 VCRUNTIME140!__C_specific_handler+160	(d:\\agent\\_work\\2\\s\\src\\vctools\\crt\\vcruntime\\src\\eh\\riscchandler.cpp:290)\r\n04 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349\r\n05 onnxruntime!onnxruntime::InferenceSession::Initialize+0\t(D:\\a\\_work\\1\\s\\onnxruntime\\core\\session\\inference_session.cc:1238)";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -596,7 +596,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "<frame id=\"03\" pdb=\"vcruntime140.amd64.pdb\" age=\"1\" guid=\"AF138C3F-2933-4097-8883-C1071B13375E\" module=\"VCRUNTIME140\" rva=\"0xB8F0\" />\r\n" +
 "Frame = <frame id=\"04\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-d905ad930ee6\" module=\"sqldk\" rva=\"0x2249f\" />                                    \n";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n03 VCRUNTIME140!__C_specific_handler+160	(d:\\agent\\_work\\2\\s\\src\\vctools\\crt\\vcruntime\\src\\eh\\riscchandler.cpp:290)\r\n04 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -607,12 +607,12 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var pdbPath = @"srv*https://msdl.microsoft.com/download/symbols";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n03 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349";
             Assert.AreEqual(expected.Trim(), ret.Trim());
             // modify the input to not have any prior PDB info - this will be an "error" case
             input = "Frame = <frame id=\"02\" name=\"sqldk.dll\" address = \"0x100440609\"/>\r\n<frame id=\"03\" name=\"sqldk.dll\" address=\"0x10042249f\" />\n";
-            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             Assert.IsTrue(ret.StartsWith("Unable to determine symbol information from XML frames"));
         }
 
@@ -628,7 +628,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "<frame id=\"01\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-d905ad930ee6\" module=\"sqldk.dll\" rva=\"0x2249f\" />" +
 "]]></value></Slot></HistogramTarget>";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "Slot_0	[count:5]:\r\n\r\n00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n\r\nSlot_1	[count:3]:\r\n\r\n00 VCRUNTIME140!__C_specific_handler+160	(d:\\agent\\_work\\2\\s\\src\\vctools\\crt\\vcruntime\\src\\eh\\riscchandler.cpp:290)\r\n01 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -640,11 +640,11 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             csr.ProcessBaseAddresses(File.ReadAllText(@"..\..\..\Tests\TestCases\ImportXEL\base_addresses.txt"));
             var pdbPath = @"..\..\..\Tests\TestCases\sqlsyms\13.0.4001.0\x64";
             var input = "<HistogramTarget truncated=\"0\" buckets=\"256\"><Slot count=\"5\"><value>0x00007FFEABD0D919        0x00007FFEABC4D45D      0x00007FFEAC0F7EE0  0x00007FFEAC0F80CF  </value></Slot></HistogramTarget>";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, cts), pdbPath, false, null, true, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, false, cts), pdbPath, false, null, true, false, false, true, false, false, null, cts);
             var expected = "Slot_0	[count:5]:\r\n\r\nsqldk!XeSosPkg::spinlock_backoff::Publish+425\r\nsqldk!SpinlockBase::Sleep+182\r\nsqlmin!Spinlock<143,7,1>::SpinToAcquireWithExponentialBackoff+363\r\nsqlmin!lck_lockInternal+2042";
             Assert.AreEqual(expected.Trim(), ret.Trim());
             input = "&lt;HistogramTarget truncated=\"0\" buckets=\"256\"&gt;&lt;Slot count=\"5\"&gt;&lt;value&gt;0x00007FFEABD0D919        0x00007FFEABC4D45D      0x00007FFEAC0F7EE0  0x00007FFEAC0F80CF  &lt;/value&gt;&lt;/Slot&gt;&lt;/HistogramTarget&gt;";
-            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, cts), pdbPath, false, null, true, false, false, true, false, false, null, cts);
+            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, false, cts), pdbPath, false, null, true, false, false, true, false, false, null, cts);
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
 
@@ -661,7 +661,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "]]></value></Slot><Slot count=\"3\"><value><![CDATA[<frame id=\"00\" pdb=\"vcruntime140.amd64.pdb\" age=\"1\" guid=\"AF138C3F-2933-4097-8883-C1071B13375E\" module=\"VCRUNTIME140.dll\" rva=\"0xB8F0\" />" +
 "<frame id=\"01\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-d905ad930ee6\" module=\"sqldk.dll\" rva=\"0x2249f\" />]]></value></Slot></HistogramTarget>";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false,cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "Annotation for histogram #1\r\nSlot_0	[count:5]:\r\n\r\n00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n\r\nAnnotation for histogram #2\r\nSlot_1	[count:5]:\r\n\r\n00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n\r\nAnnotation for histogram #2\r\nSlot_2	[count:3]:\r\n\r\n00 VCRUNTIME140!__C_specific_handler+160	(d:\\agent\\_work\\2\\s\\src\\vctools\\crt\\vcruntime\\src\\eh\\riscchandler.cpp:290)\r\n01 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -674,7 +674,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             var input = "Annotation for histogram #1    <HistogramTarget truncated=\"0\" buckets=\"256\"><Slot count=\"5\"><value>0x00007FFEABD0D919        0x00007FFEABC4D45D      0x00007FFEAC0F7EE0  0x00007FFEAC0F80CF</value></Slot></HistogramTarget>" +
                 "Annotation for histogram #2    <HistogramTarget truncated=\"0\" buckets=\"256\"><Slot count=\"5\"><value>0x00007FFEAC0F80CF  0x00007FFEAC1EE447  0x00007FFEAC1EE6F5</value></Slot></HistogramTarget>";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
             var expected = "Annotation for histogram #1\r\nSlot_0	[count:5]:\r\n\r\nsqldk!XeSosPkg::spinlock_backoff::Publish+425\r\nsqldk!SpinlockBase::Sleep+182\r\nsqlmin!Spinlock<143,7,1>::SpinToAcquireWithExponentialBackoff+363\r\nsqlmin!lck_lockInternal+2042\r\nAnnotation for histogram #2\r\nSlot_1	[count:5]:\r\n\r\nsqlmin!lck_lockInternal+2042\r\nsqlmin!MDL::LockGenericLocal+382\r\nsqlmin!MDL::LockGenericIdsLocal+101";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -686,7 +686,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             var pdbPath = @"..\..\..\Tests\TestCases\sqlsyms\13.0.4001.0\x64";
             var input = "Annotation for histogram #1    <HistogramTarget truncated=\"0\" buckets=\"256\"><Slot count=\"5\"><value>0x00007FFEABD0D919        0x00007FFEABC4D45D      </value></Slot></HistogramTarget> trailing text 1" +
                 "Annotation for histogram #2    <HistogramTarget truncated=\"0\" buckets=\"256\"><Slot count=\"5\"><value>0x00007FFEAC1EE447  0x00007FFEAC1EE6F5</value></Slot></HistogramTarget>     trailing text 2";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
             var expected = "Annotation for histogram #1\r\nSlot_0	[count:5]:\r\n\r\nsqldk!XeSosPkg::spinlock_backoff::Publish+425\r\nsqldk!SpinlockBase::Sleep+182\r\n\r\ntrailing text 1Annotation for histogram #2trailing text 2\r\nSlot_1	[count:5]:\r\n\r\nsqlmin!MDL::LockGenericLocal+382\r\nsqlmin!MDL::LockGenericIdsLocal+101";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -697,11 +697,11 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             csr.ProcessBaseAddresses(File.ReadAllText(@"..\..\..\Tests\TestCases\ImportXEL\base_addresses.txt"));
             var pdbPath = @"..\..\..\Tests\TestCases\sqlsyms\13.0.4001.0\x64";
             var input = "<HistogramTargetWrongTag truncated=\"0\" buckets=\"256\"><Slot count=\"5\"><value>0x00007FFEABD0D919        0x00007FFEABC4D45D      0x00007FFEAC0F7EE0  0x00007FFEAC0F80CF  </value></Slot></HistogramTargetWrongTag>";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
             var expected = "<HistogramTargetWrongTag\r\ntruncated=\"0\"\r\nbuckets=\"256\"><Slot\r\ncount=\"5\"><value>0x00007FFEABD0D919\r\nsqldk!SpinlockBase::Sleep+182\r\nsqlmin!Spinlock<143,7,1>::SpinToAcquireWithExponentialBackoff+363\r\nsqlmin!lck_lockInternal+2042\r\n</value></Slot></HistogramTargetWrongTag>";
             Assert.AreEqual(expected.Trim(), ret.Trim()); // we just expect the input text back as-is
             input = "<HistogramTarget truncated=\"0\" buckets=\"256\"><Slot count=\"5\"><value>0x00007FFEABD0D919        0x00007FFEABC4D45D      0x00007FFEAC0F7EE0  0x00007FFEAC0F80CF  </value></Slot></HistogramTargetWrongTag>";
-            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
+            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
             expected = "<HistogramTarget\r\ntruncated=\"0\"\r\nbuckets=\"256\"><Slot\r\ncount=\"5\"><value>0x00007FFEABD0D919\r\nsqldk!SpinlockBase::Sleep+182\r\nsqlmin!Spinlock<143,7,1>::SpinToAcquireWithExponentialBackoff+363\r\nsqlmin!lck_lockInternal+2042\r\n</value></Slot></HistogramTargetWrongTag>";
             Assert.AreEqual(expected.Trim(), ret.Trim()); // we just expect the input text back as-is
         }
@@ -717,7 +717,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "<frame id=\"03\" pdb=\"vcruntime140.amd64.pdb\" age=\"1\" guid=\"AF138C3F-2933-4097-8883-C1071B13375E\" module=\"VCRUNTIME140.dll\" rva=\"0xB8F0\" />" +
 "<frame id=\"04\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-d905ad930ee6\" module=\"sqldk.dll\" rva=\"0x2249f\" />                                    \n";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n03 VCRUNTIME140!__C_specific_handler+160	(d:\\agent\\_work\\2\\s\\src\\vctools\\crt\\vcruntime\\src\\eh\\riscchandler.cpp:290)\r\n04 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349\r\n";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -732,7 +732,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "\"KERNELBASE.dll\",\"10.0.17763.1518\",2707456,4281343292,2763414,\"kernelbase.pdb\",\"{E77E26E7-D1C4-72BB-2C05-DD17624A9E58}\",0,1\r\n" +
 "\"VCRUNTIME140.dll\",\"14.16.27033.0\",86016,1563486943,105788,\"vcruntime140.amd64.pdb\",\"{AF138C3F-2933-4097-8883-C1071B13375E}\",0,1\r\n";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             Assert.AreEqual(input.Trim(), ret.Trim());
         }
 
@@ -783,7 +783,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var cts3 = new CancellationTokenSource();
             Assert.IsTrue(csr.ProcessBaseAddresses(@"c:\mssql\binn\sqldk.dll 00000001`00400000"));
             var xeventInput = PrepareLargeXEventInput().ToString();
-            var xeStacks = await csr.GetListofCallStacksAsync(xeventInput, false, cts3);
+            var xeStacks = await csr.GetListofCallStacksAsync(xeventInput, false, false, cts3);
             var resolveStacksTask = csr.ResolveCallstacksAsync(xeStacks, @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()), cts3);
             while (true) {
                 if (resolveStacksTask.Wait(StackResolver.OperationWaitIntervalMilliseconds)) break;

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -20,6 +20,8 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         [TestMethod][TestCategory("Unit")] public void SingleLineDetection() {
             using var csr = new StackResolver();
             var PatternsToTreatAsMultiline = "BEGIN STACK DUMP|Short Stack Dump";
+            Assert.IsFalse(csr.IsInputSingleLine("05 sqldk!SOS_Scheduler::UpdateWaitTimeStats+789", PatternsToTreatAsMultiline));
+            Assert.IsFalse(csr.IsInputSingleLine(@"\r\n    sqldk+0x40609\r\n", PatternsToTreatAsMultiline));
             Assert.IsFalse(csr.IsInputSingleLine("&lt;frame id=\"00\" address=\"0xf00\" pdb=\"ntdll.pdb\" age=\"1\" guid=\"C374E059-5793-9B92-6525-386A66A2D3F5\" module=\"ntdll.dll\" rva=\"0x9F7E4\" /&gt;&lt;" +
 "frame id=\"01\" address=\"0xf00\" pdb=\"kernelbase.pdb\" age=\"1\" guid=\"E77E26E7-D1C4-72BB-2C05-DD17624A9E58\" module=\"KERNELBASE.dll\" rva=\"0x38973\" /&gt;&lt;" +
 "frame id=\"02\" address=\"0xf00\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-d905ad930ee6\" module=\"sqldk.dll\" rva=\"0x40609\" /&gt;", PatternsToTreatAsMultiline));

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -255,6 +255,8 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             var pdbPath = @"..\..\..\Tests\TestCases\SourceInformation";
             var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143", false, true, cts), pdbPath, false, null, false, true, true, true, false, false, null, cts);
             Assert.AreEqual("Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143\t(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxPkgPnp.hpp:4127)", ret.Trim());
+            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("01 Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143 03 Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143", true, true, cts), pdbPath, false, null, false, true, true, true, false, false, null, cts);
+            Assert.AreEqual("01 Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143\t(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxPkgPnp.hpp:4127)\r\n02 Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143\t(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxPkgPnp.hpp:4127)", ret.Trim());
         }
 
         /// Validate importing callstack events from XEL files into histogram buckets.

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var pdbPath = @"..\..\..\Tests\TestCases\TestBlockResolution";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Return Addr: 00007FF830D4CDA4 Module(KERNELBASE+000000000009CDA4)", false, false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Return Addr: 00007FF830D4CDA4 Module(KERNELBASE+000000000009CDA4)", false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
             Assert.AreEqual("KERNELBASE!SignalObjectAndWait+147716", ret.Trim());
         }
 
@@ -64,7 +64,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var dllPaths = new List<string> { Path.GetTempPath(), @"..\..\..\Tests\TestCases\TestOrdinal", Path.GetTempPath() };    // use different paths to validate the multi-path handling
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("ntdll!Ordinal298+00000000000004A5\r\n00007FF818405E70      Module(ntdll+0000000000091735) (Ordinal298 + 00000000000004A5)", false, false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, dllPaths, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("ntdll!Ordinal298+00000000000004A5\r\n00007FF818405E70      Module(ntdll+0000000000091735) (Ordinal298 + 00000000000004A5)", false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, dllPaths, false, false, false, true, false, false, null, cts);
             Assert.AreEqual("ntdll!NtOpenKeyEx+5\r\nntdll!NtOpenKeyEx+5", ret.Trim());
         }
 
@@ -72,7 +72,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         [TestMethod][TestCategory("Unit")] public async Task RegularSymbolHexOffset() {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("sqldk +0x40609\r\nsqldk+40609", false, false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("sqldk +0x40609\r\nsqldk+40609", false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, null, cts);
             var expectedSymbol = "sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644";
             Assert.AreEqual(expectedSymbol + Environment.NewLine + expectedSymbol, ret.Trim());
         }
@@ -81,7 +81,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         [TestMethod][TestCategory("Unit")] public async Task CorruptPDBWarning() {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("sqldk+40609", false, false, cts), @"..\..\..\Tests\TestCases\CorruptPDB", false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("sqldk+40609", false, cts), @"..\..\..\Tests\TestCases\CorruptPDB", false, null, false, false, false, true, false, false, null, cts);
             Assert.IsTrue(ret.StartsWith($"sqldk+40609 {StackResolver.WARNING_PREFIX}"));
         }
 
@@ -90,7 +90,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             Assert.IsTrue(csr.ProcessBaseAddresses(@"c:\mssql\binn\sqldk.dll 00000001`00400000"));
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("0x000000010042249f", false, false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("0x000000010042249f", false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, null, cts);
             var expectedSymbol = "sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349";
             Assert.AreEqual(expectedSymbol, ret.Trim());
         }
@@ -100,7 +100,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var cts = new CancellationTokenSource();
             var moduleAddresses = "c:\\mssql\\binn\\sqldk.dll 00000001`00400000\r\nc:\\windows\\temp\\sqldk.dll 00000001`00400000";
             Assert.IsFalse(csr.ProcessBaseAddresses(moduleAddresses));
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("0x000000010042249f\r\nsqldk+0x40609", false, false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("0x000000010042249f\r\nsqldk+0x40609", false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, null, cts);
             Assert.AreEqual("0x000000010042249f\r\nsqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644", ret.Trim());
         }
 
@@ -111,7 +111,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             Assert.IsTrue(csr.ProcessBaseAddresses(@"c:\mssql\binn\sqldk.dll 00000001`00400000"));
             var timer = new System.Diagnostics.Stopwatch();
             timer.Start();
-            await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(PrepareLargeXEventInput(), false, false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()), cts);
+            await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(PrepareLargeXEventInput(), false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()), cts);
             timer.Stop();
             Assert.IsTrue(timer.Elapsed.TotalSeconds < 45 * 60);  // 45 minutes max on GitHub hosted DSv2 runner (2 vCPU, 7 GiB RAM).
         }
@@ -199,7 +199,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         [TestMethod][TestCategory("Unit")] public async Task RegularSymbolHexOffsetNoOutputOffset() {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("sqldk+0x40609", false, false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, false, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("sqldk+0x40609", false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, false, false, false, null, cts);
             var expectedSymbol = "sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode";
             Assert.AreEqual(expectedSymbol, ret.Trim());
         }
@@ -210,7 +210,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         [TestMethod][TestCategory("Unit")] public async Task RegularSymbolHexOffsetNoOutputOffsetWithFrameNums() {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("00 sqldk+0x40609", false, false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, false, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("00 sqldk+0x40609", false, cts), @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, false, false, false, null, cts);
             var expectedSymbol = "00 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode";
             Assert.AreEqual(expectedSymbol, ret.Trim());
         }
@@ -223,7 +223,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             Assert.AreEqual(550, ret.Item1);
             Assert.IsTrue(csr.ProcessBaseAddresses(File.ReadAllText(@"..\..\..\Tests\TestCases\ImportXEL\xe_wait_base_addresses.txt")));
             var pdbPath = @"..\..\..\Tests\TestCases\sqlsyms\14.0.3192.2\x64";
-            var symres = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(ret.Item2, false, false, cts), pdbPath, false, null, false, false, false, false, false, true, null, cts);
+            var symres = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(ret.Item2, false, cts), pdbPath, false, null, false, false, false, false, false, true, null, cts);
             Assert.IsTrue(symres.Contains("sqldk!XeSosPkg::wait_completed::Publish\r\nsqldk!SOS_Scheduler::UpdateWaitTimeStats\r\nsqldk!SOS_Task::PostWait\r\nsqllang!SOS_Task::Sleep\r\nsqllang!YieldAndCheckForAbort\r\nsqllang!OptimizerUtil::YieldAndCheckForMemoryAndAbort\r\nsqllang!OptTypeVRSetArray::IFindSet\r\nsqllang!CConstraintProp::FEquivalent\r\nsqllang!CJoinEdge::FConstrainsColumnSolvably\r\nsqllang!CStCollOuterJoin::CardForColumns\r\nsqllang!CStCollGroupBy::CStCollGroupBy\r\nsqllang!CCardFrameworkSQL12::CardDistinct\r\nsqllang!CCostUtils::CalcLoopJoinCachedInfo\r\nsqllang!CCostUtils::PcctxLoopJoinHelper\r\nsqllang!COpArg::PcctxCalculateNormalizeCtx\r\nsqllang!CTask_OptInputs::Perform\r\nsqllang!CMemo::ExecuteTasks\r\nsqllang!CMemo::PerformOptimizationStage\r\nsqllang!CMemo::OptimizeQuery\r\nsqllang!COptContext::PexprSearchPlan\r\nsqllang!COptContext::PcxteOptimizeQuery\r\nsqllang!COptContext::PqteOptimizeWrapper\r\nsqllang!PqoBuild\r\nsqllang!CStmtQuery::InitQuery"));
         }
 
@@ -233,7 +233,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var pdbPath = @"..\..\..\Tests\TestCases\SourceInformation";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000+17f27", false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000+17f27", false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             Assert.AreEqual("Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143\t(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxPkgPnp.hpp:4127)", ret.Trim());
         }
 
@@ -243,7 +243,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var pdbPath = @"..\..\..\Tests\TestCases\SourceInformation";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000+17f27", false, false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000+17f27", false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
             Assert.AreEqual("Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143", ret.Trim());
         }
 
@@ -286,7 +286,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             csr.ProcessBaseAddresses(File.ReadAllText(@"..\..\..\Tests\TestCases\ImportXEL\base_addresses.txt"));
             Assert.AreEqual(20, csr.LoadedModules.Count);
             var pdbPath = @"..\..\..\Tests\TestCases\sqlsyms\13.0.4001.0\x64";
-            var symres = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(ret.Item2, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var symres = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(ret.Item2, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             Assert.IsTrue(symres.Contains("sqldk!XeSosPkg::spinlock_backoff::Publish+425\r\nsqldk!SpinlockBase::Sleep+182\r\nsqlmin!Spinlock<143,7,1>::SpinToAcquireWithExponentialBackoff+363\r\nsqlmin!lck_lockInternal+2042\r\nsqlmin!MDL::LockGenericLocal+382\r\nsqlmin!MDL::LockGenericIdsLocal+101\r\nsqlmin!CMEDCacheEntryFactory::GetProxiedCacheEntryById+263\r\nsqlmin!CMEDProxyDatabase::GetOwnerByOwnerId+122\r\nsqllang!CSECAccessAuditBase::SetSecurable+427\r\nsqllang!CSECManager::_AccessCheck+151\r\nsqllang!CSECManager::AccessCheck+2346\r\nsqllang!FHasEntityPermissionsWithAuditState+1505\r\nsqllang!FHasEntityPermissions+165\r\nsqllang!CSQLObject::FPostCacheLookup+2562\r\nsqllang!CSQLSource::Transform+2194\r\nsqllang!CSQLSource::Execute+944\r\nsqllang!CStmtExecProc::XretLocalExec+622\r\nsqllang!CStmtExecProc::XretExecExecute+1153\r\nsqllang!CXStmtExecProc::XretExecute+56\r\nsqllang!CMsqlExecContext::ExecuteStmts<1,1>+1037\r\nsqllang!CMsqlExecContext::FExecute+2718\r\nsqllang!CSQLSource::Execute+2435\r\nsqllang!process_request+3681\r\nsqllang!process_commands_internal+735"));
         }
 
@@ -297,7 +297,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             var ret = await csr.ExtractFromXELAsync(new[] { @"..\..\..\Tests\TestCases\ImportXEL\xe_wait_completed_0_132353446563350000.xel" }, false, new List<string>(new String[] { "callstack" }), cts);
             Assert.AreEqual(550, ret.Item1);
             Assert.IsTrue(ret.Item2.Contains("Tests\\TestCases\\ImportXEL\\xe_wait_completed_0_132353446563350000.xel, UTC: 2020-05-30 20:37:36.3626428, UUID: 992caa1d-ef90-4278-9821-ebdd0180db0d\"><action name='callstack'><value><![CDATA[0x00007FFAF2BD6C7C"));
-            var res = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(ret.Item2, false, false, cts), string.Empty, false, null, false, false, false, false, false, false, null, cts);
+            var res = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(ret.Item2, false, cts), string.Empty, false, null, false, false, false, false, false, false, null, cts);
             Assert.IsTrue(res.StartsWith(@"Event key: File: ..\..\..\Tests\TestCases\ImportXEL\xe_wait_completed_0_132353446563350000.xel, UTC: 2020-05-30 20:37:36.3626428, UUID: 992caa1d-ef90-4278-9821-ebdd0180db0d"));
         }
 
@@ -330,7 +330,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             csr.ProcessBaseAddresses(File.ReadAllText(@"..\..\..\Tests\TestCases\ImportXEL\base_addresses.txt"));
             var pdbPath = @"..\..\..\Tests\TestCases\sqlsyms\13.0.4001.0\x64";
             var callStack = @"callstack	          0x00007FFEABD0D919        0x00007FFEABC4D45D      0x00007FFEAC0F7EE0  0x00007FFEAC0F80CF  0x00007FFEAC1EE447  0x00007FFEAC1EE6F5  0x00007FFEAC1D48B0  0x00007FFEAC71475A  0x00007FFEA9A708F1  0x00007FFEA9991FB9  0x00007FFEA9993D21  0x00007FFEA99B59F1  0x00007FFEA99B5055  0x00007FFEA99B2B8F  0x00007FFEA9675AD1  0x00007FFEA9671EFB  0x00007FFEAA37D83D  0x00007FFEAA37D241  0x00007FFEAA379F98  0x00007FFEA96719CA  0x00007FFEA9672933  0x00007FFEA9672041  0x00007FFEA967A82B  0x00007FFEA9681542  ";
-            var symres = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(callStack, true, false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
+            var symres = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(callStack, true, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
             Assert.AreEqual("callstack\r\nsqldk!XeSosPkg::spinlock_backoff::Publish+425\r\nsqldk!SpinlockBase::Sleep+182\r\nsqlmin!Spinlock<143,7,1>::SpinToAcquireWithExponentialBackoff+363\r\nsqlmin!lck_lockInternal+2042\r\nsqlmin!MDL::LockGenericLocal+382\r\nsqlmin!MDL::LockGenericIdsLocal+101\r\nsqlmin!CMEDCacheEntryFactory::GetProxiedCacheEntryById+263\r\nsqlmin!CMEDProxyDatabase::GetOwnerByOwnerId+122\r\nsqllang!CSECAccessAuditBase::SetSecurable+427\r\nsqllang!CSECManager::_AccessCheck+151\r\nsqllang!CSECManager::AccessCheck+2346\r\nsqllang!FHasEntityPermissionsWithAuditState+1505\r\nsqllang!FHasEntityPermissions+165\r\nsqllang!CSQLObject::FPostCacheLookup+2562\r\nsqllang!CSQLSource::Transform+2194\r\nsqllang!CSQLSource::Execute+944\r\nsqllang!CStmtExecProc::XretLocalExec+622\r\nsqllang!CStmtExecProc::XretExecExecute+1153\r\nsqllang!CXStmtExecProc::XretExecute+56\r\nsqllang!CMsqlExecContext::ExecuteStmts<1,1>+1037\r\nsqllang!CMsqlExecContext::FExecute+2718\r\nsqllang!CSQLSource::Execute+2435\r\nsqllang!process_request+3681\r\nsqllang!process_commands_internal+735", symres.Trim());
         }
 
@@ -340,7 +340,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var pdbPath = @"..\..\..\Tests\TestCases\SourceInformation";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000+17f27", false, false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000+17f27", false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
             Assert.AreEqual(
                 "(Inline Function) Wdf01000!Mx::MxLeaveCriticalRegion+12	(minkernel\\wdf\\framework\\shared\\inc\\primitives\\km\\MxGeneralKm.h:198)\r\n(Inline Function) Wdf01000!FxWaitLockInternal::ReleaseLock+62	(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxWaitLock.hpp:305)\r\n(Inline Function) Wdf01000!FxEnumerationInfo::ReleaseParentPowerStateLock+62	(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxPkgPnp.hpp:510)\r\nWdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143	(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxPkgPnp.hpp:4127)",
                 ret.Trim());
@@ -359,7 +359,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             for (int frameNum = 0; frameNum < 1000; frameNum++) {
                 callstackInput.AppendLine($"Wdf01000+{rng.Next(0, 1000000)}");
             }
-            await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(callstackInput.ToString(), false, false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
+            await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(callstackInput.ToString(), false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
             // We do not need to check anything; the criteria for the test passing is that the call did not throw an unhandled exception
         }
 
@@ -369,7 +369,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var pdbPath = @"..\..\..\Tests\TestCases\SourceInformation";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000+17f27", false, false, cts), pdbPath, false, null, false, false, false, true, true, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("Wdf01000+17f27", false, cts), pdbPath, false, null, false, false, false, true, true, false, null, cts);
             Assert.AreEqual("(Inline Function) Wdf01000!Mx::MxLeaveCriticalRegion+12\r\n(Inline Function) Wdf01000!FxWaitLockInternal::ReleaseLock+62\r\n(Inline Function) Wdf01000!FxEnumerationInfo::ReleaseParentPowerStateLock+62\r\nWdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143", ret.Trim());
         }
 
@@ -377,7 +377,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var pdbPath = @"..\..\..\Tests\TestCases\SourceInformation;..\..\..\Tests\TestCases\TestOrdinal";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("00 sqldk+0x40609\r\n01 Wdf01000+17f27\r\n02 sqldk+0x40609", false, false, cts), pdbPath, false, null, false, false, false, true, true, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync("00 sqldk+0x40609\r\n01 Wdf01000+17f27\r\n02 sqldk+0x40609", false, cts), pdbPath, false, null, false, false, false, true, true, false, null, cts);
             Assert.AreEqual("00 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n01 (Inline Function) Wdf01000!Mx::MxLeaveCriticalRegion+12\r\n02 (Inline Function) Wdf01000!FxWaitLockInternal::ReleaseLock+62\r\n03 (Inline Function) Wdf01000!FxEnumerationInfo::ReleaseParentPowerStateLock+62\r\n04 Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143\r\n05 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644", ret.Trim());
         }
 
@@ -488,9 +488,9 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "\r\n\"ntdll.dll\",\"10.0.17763.1490\",2019328,462107166,2009368,\"ntdll.pdb\",\"{C374E059-5793-9B92-6525-386A66A2D3F5}\",0,1\r\n" +
 "\"KERNELBASE.dll\",\"10.0.17763.1518\",2707456,4281343292,2763414,\"kernelbase.pdb\",\"{E77E26E7-D1C4-72BB-2C05-DD17624A9E58}\",0,1\r\n" +
 "\"VCRUNTIME140.dll\",\"14.16.27033.0\",86016,1563486943,105788,\"vcruntime140.amd64.pdb\",\"{AF138C3F-2933-4097-8883-C1071B13375E}\",0,1";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), @"https://msdl.microsoft.com/download/symbols", false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), @"https://msdl.microsoft.com/download/symbols", false, null, false, true, false, true, false, false, null, cts);
             Assert.AreEqual(expected.Trim(), ret.Trim());
-            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), @"srv*https://msdl.microsoft.com/download/symbols", false, null, false, true, false, true, false, false, null, cts);
+            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), @"srv*https://msdl.microsoft.com/download/symbols", false, null, false, true, false, true, false, false, null, cts);
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
 
@@ -500,7 +500,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var cts = new CancellationTokenSource();
             var pdbPath = @"srv*https://msdl.microsoft.com/download/symbols";
             var input = "<frame id=\"00\" pdb=\"ntdll.pdb\" age=\"1\" guid=\"C374E059-5793-9B92-6525-386A66A2D3F5\" module=\"ntdll.dll\" rva=\"0x9F7E4\" />";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = @"00 ntdll!NtWaitForSingleObject+20";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -516,7 +516,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "<frame id=\"03\" pdb=\"vcruntime140.amd64.pdb\" age=\"1\" guid=\"AF138C3F-2933-4097-8883-C1071B13375E\" module=\"VCRUNTIME140.dll\" rva=\"0xB8F0\" />\r\n" +
 "Frame = <frame id=\"04\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-d905ad930ee6\" module=\"sqldk.dll\" rva=\"0x2249f\" />                                    \n";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n03 VCRUNTIME140!__C_specific_handler+160	(d:\\agent\\_work\\2\\s\\src\\vctools\\crt\\vcruntime\\src\\eh\\riscchandler.cpp:290)\r\n04 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -532,7 +532,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "<frame id=\"00\" pdb=\"ntdll.pdb\" age=\"1\" guid=\"C374E059-5793-9B92-6525-386A66A2D3F5\" module=\"ntdll.dll\" rva=\"0x9F7E4\" />" +
 "<frame id=\"01\" pdb=\"kernelbase.pdb\" age=\"1\" guid=\"E77E26E7-D1C4-72BB-2C05-DD17624A9E58\" module=\"KERNELBASE.dll\" rva=\"0x38973\" />";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
             var expected = "00 ntdll!NtWaitForSingleObject+20\r\n01 (Inline Function) Wdf01000!Mx::MxLeaveCriticalRegion+12	(minkernel\\wdf\\framework\\shared\\inc\\primitives\\km\\MxGeneralKm.h:198)\r\n02 (Inline Function) Wdf01000!FxWaitLockInternal::ReleaseLock+62	(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxWaitLock.hpp:305)\r\n03 (Inline Function) Wdf01000!FxEnumerationInfo::ReleaseParentPowerStateLock+62	(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxPkgPnp.hpp:510)\r\n04 Wdf01000!FxPkgPnp::PowerPolicyCanChildPowerUp+143	(minkernel\\wdf\\framework\\shared\\inc\\private\\common\\FxPkgPnp.hpp:4127)\r\n05 KERNELBASE!WaitForSingleObjectEx+147\r\n00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -547,7 +547,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "<frame id=\"00\" pdb=\"sqldk.pdb\" age=\"2\" guid=\"1D3FA75E-B355-40E2-87B2-E012D69785DF\" module=\"sqldk.dll\" rva=\"0xFD919\" />" +
 "<frame id=\"01\" pdb=\"sqldk.pdb\" age=\"2\" guid=\"1D3FA75E-B355-40E2-87B2-E012D69785DF\" module=\"sqldk.dll\" rva=\"0x3D45D\" />";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, true, false, null, cts);
             var expected = "00 sqldk!XeSosPkg::wait_completed::Publish+476\r\n01 sqldk!SOS_Scheduler::UpdateWaitTimeStats+1186\r\n00 sqldk!XeSosPkg::spinlock_backoff::Publish+425\r\n01 sqldk!SpinlockBase::Sleep+182\r\n";
             //var expected = "Unable to determine symbol information from XML frames - this may be caused by multiple PDB versions in the same input.";
             Assert.AreEqual(expected.Trim(), ret.Trim());
@@ -564,7 +564,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "&lt;frame id=\"03\" pdb=\"vcruntime140.amd64.pdb\" age=\"1\" guid=\"AF138C3F-2933-4097-8883-C1071B13375E\" module=\"VCRUNTIME140.dll\" rva=\"0xB8F0\" /&gt;" +
 "&lt;frame id=\"04\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-d905ad930ee6\" module=\"sqldk.dll\" rva=\"0x2249f\" /&gt;";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n03 VCRUNTIME140!__C_specific_handler+160	(d:\\agent\\_work\\2\\s\\src\\vctools\\crt\\vcruntime\\src\\eh\\riscchandler.cpp:290)\r\n04 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -581,7 +581,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "Frame = <frame id=\"04\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-d905ad930ee6\" module=\"sqldk.dll\" rva=\"0x2249f\" />                                    \n" +
 "Frame = <frame id=\"05\" pdb=\"onnxruntime.pdb\" age=\"1\" guid=\"D1106301-B61B-4655-BFAC-DC1EA8911A7E\" module=\"onnxruntime.dll\" rva=\"0x4fd50\" />";
 
-                        var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+                        var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n03 VCRUNTIME140!__C_specific_handler+160	(d:\\agent\\_work\\2\\s\\src\\vctools\\crt\\vcruntime\\src\\eh\\riscchandler.cpp:290)\r\n04 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349\r\n05 onnxruntime!onnxruntime::InferenceSession::Initialize+0\t(D:\\a\\_work\\1\\s\\onnxruntime\\core\\session\\inference_session.cc:1238)";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -596,7 +596,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "<frame id=\"03\" pdb=\"vcruntime140.amd64.pdb\" age=\"1\" guid=\"AF138C3F-2933-4097-8883-C1071B13375E\" module=\"VCRUNTIME140\" rva=\"0xB8F0\" />\r\n" +
 "Frame = <frame id=\"04\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-d905ad930ee6\" module=\"sqldk\" rva=\"0x2249f\" />                                    \n";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n03 VCRUNTIME140!__C_specific_handler+160	(d:\\agent\\_work\\2\\s\\src\\vctools\\crt\\vcruntime\\src\\eh\\riscchandler.cpp:290)\r\n04 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -607,12 +607,12 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var csr = new StackResolver();
             using var cts = new CancellationTokenSource();
             var pdbPath = @"srv*https://msdl.microsoft.com/download/symbols";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n03 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349";
             Assert.AreEqual(expected.Trim(), ret.Trim());
             // modify the input to not have any prior PDB info - this will be an "error" case
             input = "Frame = <frame id=\"02\" name=\"sqldk.dll\" address = \"0x100440609\"/>\r\n<frame id=\"03\" name=\"sqldk.dll\" address=\"0x10042249f\" />\n";
-            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             Assert.IsTrue(ret.StartsWith("Unable to determine symbol information from XML frames"));
         }
 
@@ -628,7 +628,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "<frame id=\"01\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-d905ad930ee6\" module=\"sqldk.dll\" rva=\"0x2249f\" />" +
 "]]></value></Slot></HistogramTarget>";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "Slot_0	[count:5]:\r\n\r\n00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n\r\nSlot_1	[count:3]:\r\n\r\n00 VCRUNTIME140!__C_specific_handler+160	(d:\\agent\\_work\\2\\s\\src\\vctools\\crt\\vcruntime\\src\\eh\\riscchandler.cpp:290)\r\n01 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -640,11 +640,11 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             csr.ProcessBaseAddresses(File.ReadAllText(@"..\..\..\Tests\TestCases\ImportXEL\base_addresses.txt"));
             var pdbPath = @"..\..\..\Tests\TestCases\sqlsyms\13.0.4001.0\x64";
             var input = "<HistogramTarget truncated=\"0\" buckets=\"256\"><Slot count=\"5\"><value>0x00007FFEABD0D919        0x00007FFEABC4D45D      0x00007FFEAC0F7EE0  0x00007FFEAC0F80CF  </value></Slot></HistogramTarget>";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, false, cts), pdbPath, false, null, true, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, cts), pdbPath, false, null, true, false, false, true, false, false, null, cts);
             var expected = "Slot_0	[count:5]:\r\n\r\nsqldk!XeSosPkg::spinlock_backoff::Publish+425\r\nsqldk!SpinlockBase::Sleep+182\r\nsqlmin!Spinlock<143,7,1>::SpinToAcquireWithExponentialBackoff+363\r\nsqlmin!lck_lockInternal+2042";
             Assert.AreEqual(expected.Trim(), ret.Trim());
             input = "&lt;HistogramTarget truncated=\"0\" buckets=\"256\"&gt;&lt;Slot count=\"5\"&gt;&lt;value&gt;0x00007FFEABD0D919        0x00007FFEABC4D45D      0x00007FFEAC0F7EE0  0x00007FFEAC0F80CF  &lt;/value&gt;&lt;/Slot&gt;&lt;/HistogramTarget&gt;";
-            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, false, cts), pdbPath, false, null, true, false, false, true, false, false, null, cts);
+            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, cts), pdbPath, false, null, true, false, false, true, false, false, null, cts);
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
 
@@ -661,7 +661,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "]]></value></Slot><Slot count=\"3\"><value><![CDATA[<frame id=\"00\" pdb=\"vcruntime140.amd64.pdb\" age=\"1\" guid=\"AF138C3F-2933-4097-8883-C1071B13375E\" module=\"VCRUNTIME140.dll\" rva=\"0xB8F0\" />" +
 "<frame id=\"01\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-d905ad930ee6\" module=\"sqldk.dll\" rva=\"0x2249f\" />]]></value></Slot></HistogramTarget>";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false,cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "Annotation for histogram #1\r\nSlot_0	[count:5]:\r\n\r\n00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n\r\nAnnotation for histogram #2\r\nSlot_1	[count:5]:\r\n\r\n00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n\r\nAnnotation for histogram #2\r\nSlot_2	[count:3]:\r\n\r\n00 VCRUNTIME140!__C_specific_handler+160	(d:\\agent\\_work\\2\\s\\src\\vctools\\crt\\vcruntime\\src\\eh\\riscchandler.cpp:290)\r\n01 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -674,7 +674,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             var input = "Annotation for histogram #1    <HistogramTarget truncated=\"0\" buckets=\"256\"><Slot count=\"5\"><value>0x00007FFEABD0D919        0x00007FFEABC4D45D      0x00007FFEAC0F7EE0  0x00007FFEAC0F80CF</value></Slot></HistogramTarget>" +
                 "Annotation for histogram #2    <HistogramTarget truncated=\"0\" buckets=\"256\"><Slot count=\"5\"><value>0x00007FFEAC0F80CF  0x00007FFEAC1EE447  0x00007FFEAC1EE6F5</value></Slot></HistogramTarget>";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
             var expected = "Annotation for histogram #1\r\nSlot_0	[count:5]:\r\n\r\nsqldk!XeSosPkg::spinlock_backoff::Publish+425\r\nsqldk!SpinlockBase::Sleep+182\r\nsqlmin!Spinlock<143,7,1>::SpinToAcquireWithExponentialBackoff+363\r\nsqlmin!lck_lockInternal+2042\r\nAnnotation for histogram #2\r\nSlot_1	[count:5]:\r\n\r\nsqlmin!lck_lockInternal+2042\r\nsqlmin!MDL::LockGenericLocal+382\r\nsqlmin!MDL::LockGenericIdsLocal+101";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -686,7 +686,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             var pdbPath = @"..\..\..\Tests\TestCases\sqlsyms\13.0.4001.0\x64";
             var input = "Annotation for histogram #1    <HistogramTarget truncated=\"0\" buckets=\"256\"><Slot count=\"5\"><value>0x00007FFEABD0D919        0x00007FFEABC4D45D      </value></Slot></HistogramTarget> trailing text 1" +
                 "Annotation for histogram #2    <HistogramTarget truncated=\"0\" buckets=\"256\"><Slot count=\"5\"><value>0x00007FFEAC1EE447  0x00007FFEAC1EE6F5</value></Slot></HistogramTarget>     trailing text 2";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
             var expected = "Annotation for histogram #1\r\nSlot_0	[count:5]:\r\n\r\nsqldk!XeSosPkg::spinlock_backoff::Publish+425\r\nsqldk!SpinlockBase::Sleep+182\r\n\r\ntrailing text 1Annotation for histogram #2trailing text 2\r\nSlot_1	[count:5]:\r\n\r\nsqlmin!MDL::LockGenericLocal+382\r\nsqlmin!MDL::LockGenericIdsLocal+101";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -697,11 +697,11 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             csr.ProcessBaseAddresses(File.ReadAllText(@"..\..\..\Tests\TestCases\ImportXEL\base_addresses.txt"));
             var pdbPath = @"..\..\..\Tests\TestCases\sqlsyms\13.0.4001.0\x64";
             var input = "<HistogramTargetWrongTag truncated=\"0\" buckets=\"256\"><Slot count=\"5\"><value>0x00007FFEABD0D919        0x00007FFEABC4D45D      0x00007FFEAC0F7EE0  0x00007FFEAC0F80CF  </value></Slot></HistogramTargetWrongTag>";
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
             var expected = "<HistogramTargetWrongTag\r\ntruncated=\"0\"\r\nbuckets=\"256\"><Slot\r\ncount=\"5\"><value>0x00007FFEABD0D919\r\nsqldk!SpinlockBase::Sleep+182\r\nsqlmin!Spinlock<143,7,1>::SpinToAcquireWithExponentialBackoff+363\r\nsqlmin!lck_lockInternal+2042\r\n</value></Slot></HistogramTargetWrongTag>";
             Assert.AreEqual(expected.Trim(), ret.Trim()); // we just expect the input text back as-is
             input = "<HistogramTarget truncated=\"0\" buckets=\"256\"><Slot count=\"5\"><value>0x00007FFEABD0D919        0x00007FFEABC4D45D      0x00007FFEAC0F7EE0  0x00007FFEAC0F80CF  </value></Slot></HistogramTargetWrongTag>";
-            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, false, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
+            ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, true, cts), pdbPath, false, null, false, false, false, true, false, false, null, cts);
             expected = "<HistogramTarget\r\ntruncated=\"0\"\r\nbuckets=\"256\"><Slot\r\ncount=\"5\"><value>0x00007FFEABD0D919\r\nsqldk!SpinlockBase::Sleep+182\r\nsqlmin!Spinlock<143,7,1>::SpinToAcquireWithExponentialBackoff+363\r\nsqlmin!lck_lockInternal+2042\r\n</value></Slot></HistogramTargetWrongTag>";
             Assert.AreEqual(expected.Trim(), ret.Trim()); // we just expect the input text back as-is
         }
@@ -717,7 +717,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "<frame id=\"03\" pdb=\"vcruntime140.amd64.pdb\" age=\"1\" guid=\"AF138C3F-2933-4097-8883-C1071B13375E\" module=\"VCRUNTIME140.dll\" rva=\"0xB8F0\" />" +
 "<frame id=\"04\" pdb=\"SqlDK.pdb\" age=\"2\" guid=\"6a193443-3512-464b-8b8e-d905ad930ee6\" module=\"sqldk.dll\" rva=\"0x2249f\" />                                    \n";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             var expected = "00 ntdll!NtWaitForSingleObject+20\r\n01 KERNELBASE!WaitForSingleObjectEx+147\r\n02 sqldk!MemoryClerkInternal::AllocatePagesWithFailureMode+644\r\n03 VCRUNTIME140!__C_specific_handler+160	(d:\\agent\\_work\\2\\s\\src\\vctools\\crt\\vcruntime\\src\\eh\\riscchandler.cpp:290)\r\n04 sqldk!Spinlock<244,2,1>::SpinToAcquireWithExponentialBackoff+349\r\n";
             Assert.AreEqual(expected.Trim(), ret.Trim());
         }
@@ -732,7 +732,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 "\"KERNELBASE.dll\",\"10.0.17763.1518\",2707456,4281343292,2763414,\"kernelbase.pdb\",\"{E77E26E7-D1C4-72BB-2C05-DD17624A9E58}\",0,1\r\n" +
 "\"VCRUNTIME140.dll\",\"14.16.27033.0\",86016,1563486943,105788,\"vcruntime140.amd64.pdb\",\"{AF138C3F-2933-4097-8883-C1071B13375E}\",0,1\r\n";
 
-            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
+            var ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
             Assert.AreEqual(input.Trim(), ret.Trim());
         }
 
@@ -783,7 +783,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             using var cts3 = new CancellationTokenSource();
             Assert.IsTrue(csr.ProcessBaseAddresses(@"c:\mssql\binn\sqldk.dll 00000001`00400000"));
             var xeventInput = PrepareLargeXEventInput().ToString();
-            var xeStacks = await csr.GetListofCallStacksAsync(xeventInput, false, false, cts3);
+            var xeStacks = await csr.GetListofCallStacksAsync(xeventInput, false, cts3);
             var resolveStacksTask = csr.ResolveCallstacksAsync(xeStacks, @"..\..\..\Tests\TestCases\TestOrdinal", false, null, false, false, false, true, false, false, Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()), cts3);
             while (true) {
                 if (resolveStacksTask.Wait(StackResolver.OperationWaitIntervalMilliseconds)) break;


### PR DESCRIPTION
* Use the address offset and IDiaSession::findLinesByAddr to avoid an
  expensive loop through the entire symbol address range

* Directly invoke ProcessFrameModuleOffset on effective RVA to avoid
  having to again parse the simulated frame, thereby gaining speed and
  streamlining code.

* Add tests for relookup of single-line stacks /w frame nums and single-line
  input detection.

* Fix some corner cases for single-line input detection for symbol re-lookup

* Add specific handling for single-line callstacks in relookup case
