### PR TITLE
Simplify and fix the detection of XEL fields / actions

### DIFF
--- a/Engine/StackResolver.cs
+++ b/Engine/StackResolver.cs
@@ -29,8 +29,8 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         private static readonly Regex rgxAlreadySymbolizedFrame = new (@"((?<framenum>\d+)\s+)*(?<module>\w+)(\.(dll|exe))*!(?<symbolizedfunc>.+?)\s*\+\s*(0[xX])*(?<offset>[0-9a-fA-F]+)\s*", rgxOptions);
         private static readonly Regex rgxmoduleaddress = new (@"^\s*(?<filepath>.+)(\t+| +)(?<baseaddress>(0x)?[0-9a-fA-F`]+)\s*$", RegexOptions.Multiline);
 
-        public Task<Tuple<List<string>, List<string>>> GetDistinctXELFieldsAsync(string[] xelFiles, int eventsToSample, CancellationTokenSource cts) {
-            return XELHelper.GetDistinctXELActionsFieldsAsync(xelFiles, eventsToSample, cts);
+        public Task<Tuple<List<string>, List<string>>> GetDistinctXELFieldsAsync(string[] xelFiles, int eventsToSample) {
+            return XELHelper.GetDistinctXELActionsFieldsAsync(xelFiles, eventsToSample);
         }
 
         /// Public method which to help import XEL files

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -223,9 +223,8 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 
         private async Task<List<string>> GetUserSelectedXEFieldsAsync(string[] fileNames) {
             using var fieldsListDialog = new FieldSelection();
-            using var cts = new CancellationTokenSource();
             fieldsListDialog.Text = "Select relevant XEvent fields";
-            var xeEventItems = await this._resolver.GetDistinctXELFieldsAsync(fileNames, 1000, cts);
+            var xeEventItems = await this._resolver.GetDistinctXELFieldsAsync(fileNames, 1000);
             if (xeEventItems.Item1.Count + xeEventItems.Item2.Count == 0) return new List<string>();
             fieldsListDialog.AllActions = xeEventItems.Item1;
             fieldsListDialog.AllFields = xeEventItems.Item2;

--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -305,8 +305,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 
         [TestMethod][TestCategory("Unit")] public async Task XELActionsAndFieldsAsync() {
             using var csr = new StackResolver();
-            using var cts = new CancellationTokenSource();
-            var ret = await csr.GetDistinctXELFieldsAsync(new[] { @"..\..\..\Tests\TestCases\ImportXEL\xe_wait_completed_0_132353446563350000.xel" }, 1000, cts);
+            var ret = await csr.GetDistinctXELFieldsAsync(new[] { @"..\..\..\Tests\TestCases\ImportXEL\xe_wait_completed_0_132353446563350000.xel" }, 5);
             Assert.AreEqual(1, ret.Item1.Count);   // just the callstack action
             Assert.AreEqual("callstack", ret.Item1.First());    // verify the name
             Assert.AreEqual(5, ret.Item2.Count);   // 5 fields
@@ -316,8 +315,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 
         [TestMethod][TestCategory("Unit")] public async Task XELActionsAndFieldsAsyncMultipleFiles() {
             using var csr = new StackResolver();
-            using var cts = new CancellationTokenSource();
-            var ret = await csr.GetDistinctXELFieldsAsync(new[] { @"..\..\..\Tests\TestCases\ImportXEL\xe_wait_completed_0_132353446563350000.xel", @"..\..\..\Tests\TestCases\ImportXEL\XESpins_0_131627061603030000.xel" }, 1000, cts);
+            var ret = await csr.GetDistinctXELFieldsAsync(new[] { @"..\..\..\Tests\TestCases\ImportXEL\xe_wait_completed_0_132353446563350000.xel", @"..\..\..\Tests\TestCases\ImportXEL\XESpins_0_131627061603030000.xel" }, 5);
             Assert.AreEqual(1, ret.Item1.Count);   // just the callstack action
             Assert.AreEqual("callstack", ret.Item1.First());    // verify the name
             Assert.AreEqual(9, ret.Item2.Count);   // 9 fields in total across the 2 XEL files
@@ -775,15 +773,6 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             }
             Assert.AreEqual(0, xelTask.Result.Item1);
             Assert.AreEqual(StackResolver.OperationCanceled, xelTask.Result.Item2);
-
-            using var cts2 = new CancellationTokenSource();
-            var xelFieldsTask = csr.GetDistinctXELFieldsAsync(new[] { @"..\..\..\Tests\TestCases\ImportXEL\XESpins_0_131627061603030000.xel" }, int.MaxValue, cts2);
-            while (true) {
-                if (xelFieldsTask.Wait(StackResolver.OperationWaitIntervalMilliseconds)) break;
-                cts2.Cancel();
-            }
-            Assert.AreEqual(0, xelFieldsTask.Result.Item1.Count);
-            Assert.AreEqual(0, xelFieldsTask.Result.Item2.Count);
 
             Assert.IsTrue(csr.ProcessBaseAddresses(@"c:\mssql\binn\sqldk.dll 00000001`00400000"));
             var xeventInput = PrepareLargeXEventInput().ToString();


### PR DESCRIPTION
* Fixes a exception being raised when extracting fields / actions from multiple XEL files, and if the earlier file had reached sampling limit.

* Removes cancellation support for this XEL fields / action detection method, thereby simplifying the implementation. As this method is typically very quick (as it is sampled) the lack of cancellation is acceptable.