### PR TITLE
Call SymSetParentWindow to ensure modal UI

### DIFF
--- a/Engine/SafeNativeMethods.cs
+++ b/Engine/SafeNativeMethods.cs
@@ -62,5 +62,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         [DllImport("dbghelp.dll")] public static extern bool SymCleanup(IntPtr hProcess);
 
         [DllImport("dbghelp.dll", CharSet = CharSet.Unicode)] public static extern bool SymInitialize(IntPtr hProcess, [MarshalAs(UnmanagedType.LPWStr)] string UserSearchPath, bool fInvadeProcess);
+
+        [DllImport("dbghelp.dll")] public static extern bool SymSetParentWindow(IntPtr hWnd);
     }
 }

--- a/Engine/SymSrvHelpers.cs
+++ b/Engine/SymSrvHelpers.cs
@@ -22,6 +22,9 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             var retval = new List<string>();
             Contract.Requires(null != syms);
             Contract.Requires(null != parent);
+
+            if (!SafeNativeMethods.SymSetParentWindow(System.Diagnostics.Process.GetCurrentProcess().MainWindowHandle)) return retval;
+
             if (!SafeNativeMethods.SymInitialize((IntPtr)(-1), symPath, false)) return retval;
             int progress = 0;
             foreach (var sym in syms) {


### PR DESCRIPTION
In some cases, dbghelp / symsrv may pop up UI dialogs, such as to authenticate to a symbol server. We want those dialogs to be modal so that they are clearly visible to the user. Calling SymSetParentWindow ensures the modal nature of such possible UI elements.