### PR TITLE
Update debugger nugets to 20250211.1226.0

### DIFF
--- a/Engine/SQLCallStackResolver.Engine.csproj
+++ b/Engine/SQLCallStackResolver.Engine.csproj
@@ -107,12 +107,12 @@
     </ContentWithTargetPath>
   </ItemGroup>
   <ItemGroup>
-    <ContentWithTargetPath Include="..\packages\Microsoft.Debugging.Platform.DbgEng.20240911.1650.0\content\amd64\dbghelp.dll">
+    <ContentWithTargetPath Include="..\packages\Microsoft.Debugging.Platform.DbgEng.20250211.1226.0\content\amd64\dbghelp.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>dbghelp.dll</TargetPath>
       <Link>DebuggerFiles\dbghelp.dll</Link>
     </ContentWithTargetPath>
-    <ContentWithTargetPath Include="..\packages\Microsoft.Debugging.Platform.SymSrv.20240911.1650.0\content\amd64\symsrv.dll">
+    <ContentWithTargetPath Include="..\packages\Microsoft.Debugging.Platform.SymSrv.20250211.1226.0\content\amd64\symsrv.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>symsrv.dll</TargetPath>
       <Link>DebuggerFiles\symsrv.dll</Link>

--- a/Engine/packages.config
+++ b/Engine/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--// Copyright (c) Microsoft Corporation. Licensed under the MIT License - see LICENSE file in this repo.-->
 <packages>
-  <package id="Microsoft.Debugging.Platform.DbgEng" version="20240911.1650.0" targetFramework="net472" />
-  <package id="Microsoft.Debugging.Platform.SymSrv" version="20240911.1650.0" targetFramework="net472" />
+  <package id="Microsoft.Debugging.Platform.DbgEng" version="20250211.1226.0" targetFramework="net472" />
+  <package id="Microsoft.Debugging.Platform.SymSrv" version="20250211.1226.0" targetFramework="net472" />
   <package id="Microsoft.SqlServer.XEvent.XELite" version="2024.2.5.1" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Collections.Immutable" version="8.0.0" targetFramework="net472" />

--- a/utils/getBuildPreReqs.ps1
+++ b/utils/getBuildPreReqs.ps1
@@ -1,5 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License - see LICENSE file in this repo.
+Remove-Item -force "DIA/*"
 if (-not (Test-Path DIA/Dia2Lib.dll)) {
     pushd "$env:TEMP"
     midl.exe /x64 /I "$env:VSINSTALLDIR/DIA SDK/include" "$env:VSINSTALLDIR/DIA SDK/idl/dia2.idl" /tlb dia2.tlb
@@ -18,5 +19,5 @@ if ((dir "DIA/*").Length -ne 3)
 $diaManifestPath = "DIA/msdia140.dll.manifest"
 (Get-Content $diaManifestPath).Replace("DIA/msdia140.dll", "msdia140.dll") -Replace " description", " threadingModel=`"Both`" description " | Set-Content $diaManifestPath
 
-@(dir "../packages/Microsoft.Debugging.Platform.DbgEng.20240911.1650.0/content/amd64/dbghelp.dll").VersionInfo.ToString()
-@(dir "../packages/Microsoft.Debugging.Platform.SymSrv.20240911.1650.0/content/amd64/symsrv.dll").VersionInfo.ToString()
+@(dir "../packages/Microsoft.Debugging.Platform.DbgEng.20250211.1226.0/content/amd64/dbghelp.dll").VersionInfo.ToString()
+@(dir "../packages/Microsoft.Debugging.Platform.SymSrv.20250211.1226.0/content/amd64/symsrv.dll").VersionInfo.ToString()


### PR DESCRIPTION
* Update debugger nugets to 20250211 versions.
* Force delete DIA subfolder to ensure that the manifest and DLL are regenerated cleanly for all builds.