### PR TITLE
Handle truncated XML frame info gracefully

### DIFF
--- a/Tests/Tests.cs
+++ b/Tests/Tests.cs
@@ -616,7 +616,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             // modify the input to not have any prior PDB info - this will be an "error" case
             input = "Frame = <frame id=\"02\" name=\"sqldk.dll\" address = \"0x100440609\"/>\r\n<frame id=\"03\" name=\"sqldk.dll\" address=\"0x10042249f\" />\n";
             ret = await csr.ResolveCallstacksAsync(await csr.GetListofCallStacksAsync(input, false, cts), pdbPath, false, null, false, true, false, true, false, false, null, cts);
-            Assert.IsTrue(ret.StartsWith("Unable to determine symbol information from XML frames"));
+            Assert.AreEqual("<frame id=\"02\" name=\"sqldk.dll\" address = \"0x100440609\"/>\r\n<frame id=\"03\" name=\"sqldk.dll\" address=\"0x10042249f\" />", ret.Trim());
         }
 
         /// End-to-end test with XE histogram target and XML frames.


### PR DESCRIPTION
When the XML frame has insufficient information, gracefully handle the case by returning the input as-is, instead of the earlier behavior of throwing an internal exception and failing.