### PR TITLE
Handle SQL Server 2022+ histogram without CDATA

### DIFF
--- a/Engine/StackResolver.cs
+++ b/Engine/StackResolver.cs
@@ -440,6 +440,10 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
                         inputCallstackText = Regex.Replace(inputCallstackText, @"(?<prefix>.*?)(?<starttag>\<HistogramTarget)(?<trailing>.+?\<\/HistogramTarget\>)",
                             (Match m) => { return $"{m.Groups["starttag"].Value} annotation=\"{System.Net.WebUtility.HtmlEncode(m.Groups["prefix"].Value.Replace("\r", string.Empty).Replace("\n", string.Empty).Trim())}\" {m.Groups["trailing"].Value}"; }
                             , RegexOptions.Singleline);
+
+                        // handle the case seen in SQL Server 2022+ where there is no CDATA section in the HistogramTarget XML
+                        if (!inputCallstackText.Contains("<![CDATA[")) inputCallstackText = inputCallstackText.Replace("<value><frame", "<value><![CDATA[<frame").Replace(" /></value>", " />]]></value>");
+
                         inputCallstackText = $"<Histograms>{inputCallstackText}</Histograms>";
                     }
                 }

--- a/GUI/App.config
+++ b/GUI/App.config
@@ -23,8 +23,14 @@
 			<dependentAssembly><assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" /><bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0" /></dependentAssembly>
 		</assemblyBinding>
 	</runtime>
- <userSettings><Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver.Properties.Settings>
-   <setting name="promptForClipboardPaste" serializeAs="String"><value>True</value></setting>
-   <setting name="choiceForClipboardPaste" serializeAs="String"><value>False</value></setting>
-  </Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver.Properties.Settings></userSettings>
+	<userSettings>
+		<Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver.Properties.Settings>
+			<setting name="promptForClipboardPaste" serializeAs="String">
+				<value>True</value>
+			</setting>
+			<setting name="choiceForClipboardPaste" serializeAs="String">
+				<value>False</value>
+			</setting>
+		</Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver.Properties.Settings>
+	</userSettings>
 </configuration>


### PR DESCRIPTION
* In SQL Server 2022 XE histogram output, the internal frame XML elements are not surrounded by a CDATA element; this case is now handled correctly.
* In an unrelated change, "format" the GUI app config's settings section to the normal form; for some reason local builds were not handling the compact XML form without newlines correctly.