### PR TITLE
Handle very large inputs

### DIFF
--- a/Engine/DLLOrdinalHelper.cs
+++ b/Engine/DLLOrdinalHelper.cs
@@ -13,12 +13,10 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
         }
 
         /// This function loads DLLs from a specified path, so that we can then build the DLL export's ordinal / address map
-        internal string[] LoadDllsIfApplicable(string[] callstackFrames, bool recurse, List<string> dllPaths) {
+        internal List<string> LoadDllsIfApplicable(List<string> callstackFrames, bool recurse, List<string> dllPaths) {
             if (dllPaths == null) return callstackFrames;
-
-            var processedFrames = new string[callstackFrames.Length];
-            for (var idx = 0; idx < callstackFrames.Length; idx++) {
-                var callstack = callstackFrames[idx];
+            var processedFrames = new List<string>(callstackFrames.Count);
+            foreach (var callstack in callstackFrames) {
                 // first we seek out distinct module names in this call stack
                 // note that such frames will only be seen in the call stack when trace flag 3656 is enabled, but there were no PDBs in the BINN folder
                 // sample frames are given below
@@ -47,7 +45,7 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
 
                 // finally do a pattern based replace the replace method calls a delegate (ReplaceOrdinalWithRealOffset) which figures
                 // out the start address of the ordinal and then computes the actual offset
-                processedFrames[idx] = fullpattern.Replace(callstack, ReplaceOrdinalWithRealOffset);
+                processedFrames.Add(fullpattern.Replace(callstack, ReplaceOrdinalWithRealOffset));
             }
             return processedFrames;
         }

--- a/Engine/StackDetails.cs
+++ b/Engine/StackDetails.cs
@@ -24,14 +24,21 @@ namespace Microsoft.SqlServer.Utils.Misc.SQLCallStackResolver {
             set { this._callStack = value; }
         }
 
-        public string[] CallstackFrames {
+        public List<string> CallstackFrames {
             get {
                 // sometimes we see call stacks which are arranged horizontally (this typically is seen when copy-pasting directly
                 // from the SSMS XEvent window (copying the callstack field without opening it in its own viewer)
                 // in that case, space is a valid delimiter, and we need to support that as an option
                 var delims = this._framesOnSingleLine ? new char[] { '\t', '\n' } : new char[] { '\n' };
                 if (!this._relookupSource && this._framesOnSingleLine) delims = delims.Append(' ').ToArray();
-                return this._callStack.Replace("\r", string.Empty).Split(delims);
+                var result = new List<string>();
+                using (var reader = new StringReader(this._callStack.Replace("\r", string.Empty))) {
+                    string line;
+                    while ((line = reader.ReadLine()) != null) {
+                        result.AddRange(line.Split(delims, StringSplitOptions.RemoveEmptyEntries));
+                    }
+                }
+                return result;
             }
         }
         public string Resolvedstack {


### PR DESCRIPTION
- Switch to using List<string> instead of string[] to avoid exceeding array dimension limits when parsing large inputs.
- Operate on individual lines when returning the CallstackFrames property, to avoid having to hit string.Split() array limits.
- Update other method signatures to use List<string> accordingly.

These changes fix #149.